### PR TITLE
Fix stream reader benchmark

### DIFF
--- a/stream_test.go
+++ b/stream_test.go
@@ -830,7 +830,7 @@ func BenchmarkStreamReader(b *B) {
 			NoBlock: true,
 		})
 
-		for _, _, ok := r.Next(); ok; _, _, ok = r.Next() {
+		for _, entries, ok := r.Next(); ok && len(entries) > 0; _, entries, ok = r.Next() {
 			benchErr = r.Err()
 		}
 	}


### PR DESCRIPTION
The stream reader benchmark relied only on the `ok` return value of `StreamReader.Next` to determine when to stop the loop, which resulted in an infinite loop since `ok` was changed to return `ok == true` even if no entries were read shortly before being merged.