### PR TITLE
Update parallelism and pool size calculation in benchmarks

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -240,7 +240,7 @@ func BenchmarkParallelGetSet(b *B) {
 
 func fillRedigoPool(pool *redigo.Pool) {
 	var conns []redigo.Conn
-	for pool.MaxActive > pool.ActiveCount() {
+	for pool.MaxIdle > pool.ActiveCount() {
 		conns = append(conns, pool.Get())
 	}
 	for _, conn := range conns {


### PR DESCRIPTION
This changes the number of goroutines in benchmarks from GOMAXPROCS^2*8 to GOMAXPROCS^2 which is easier to reason about and fixes the pool sizing.

Updates #67