### PR TITLE
Optimize command encoding and decoding a bit 

### DIFF
--- a/internal/bytesutil/bytesutil.go
+++ b/internal/bytesutil/bytesutil.go
@@ -175,8 +175,14 @@ func ReadNDiscard(r io.Reader, n int) error {
 
 	if n == 0 {
 		return nil
-	} else if d, ok := r.(discarder); ok {
-		_, err := d.Discard(n)
+	}
+
+	switch v := r.(type) {
+	case discarder:
+		_, err := v.Discard(n)
+		return err
+	case io.Seeker:
+		_, err := v.Seek(int64(n), io.SeekCurrent)
 		return err
 	}
 


### PR DESCRIPTION
While benchmarking today I found that we spend quite a lot of time in `defer`s and calls to `bytesutil.MultiWrite` as well as discarding data.

Most of the `defer`s and `bytes.MultiWrite` calls come from encoding the commands, which currently need `2+len(args)` `defer`s and `bytes.MultiWrite` calls per command.

The overhead in discarding data comes from passing a `*bytes.Reader` to `bytesutil.ReadNDiscard` which can currently not use a fast-path.

This PR fixes both cases and improves performance quite a bit for the pipelined benchmarks. The non-pipelined benchmarks don't improve, and are not as stable as the pipelined benchmarks, since they are mostly constrained by syscall overhead in both radix and Redis.

```
name                                   old time/op    new time/op    delta
SerialGetSet/radix-16                    45.0µs ± 2%    43.7µs ± 1%   -2.94%  (p=0.008 n=5+5)
ParallelGetSet/radix/no_pipelining-16    16.0µs ± 7%    17.5µs ± 5%   +9.44%  (p=0.016 n=5+5)
ParallelGetSet/radix/one_pipeline-16     6.16µs ± 0%    4.85µs ± 0%  -21.26%  (p=0.008 n=5+5)
ParallelGetSet/radix/default-16          4.14µs ± 1%    3.43µs ± 0%  -17.22%  (p=0.008 n=5+5)

name                                   old alloc/op   new alloc/op   delta
SerialGetSet/radix-16                     67.0B ± 0%     67.0B ± 0%     ~     (all equal)
ParallelGetSet/radix/no_pipelining-16      116B ± 0%      116B ± 0%     ~     (all equal)
ParallelGetSet/radix/one_pipeline-16      70.0B ± 0%     70.0B ± 0%     ~     (all equal)
ParallelGetSet/radix/default-16           71.0B ± 0%     72.0B ± 0%   +1.41%  (p=0.008 n=5+5)

name                                   old allocs/op  new allocs/op  delta
SerialGetSet/radix-16                      4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ParallelGetSet/radix/no_pipelining-16      6.00 ± 0%      6.00 ± 0%     ~     (all equal)
ParallelGetSet/radix/one_pipeline-16       4.00 ± 0%      4.00 ± 0%     ~     (all equal)
ParallelGetSet/radix/default-16            4.00 ± 0%      4.00 ± 0%     ~     (all equal)
```

I haven't looked at the `ParallelGetSet/radix/no_pipelining` regression, but it was probably a problem with my test system.