### PR TITLE
Optimize performance and allocations of Scanner

### DIFF
--- a/pipeliner.go
+++ b/pipeliner.go
@@ -20,7 +20,7 @@ var blockingCmds = map[string]bool{
 	"XREAD":      true,
 	"XREADGROUP": true,
 
-	"SAVE":  true,
+	"SAVE": true,
 }
 
 type pipeliner struct {

--- a/scanner.go
+++ b/scanner.go
@@ -67,7 +67,6 @@ type scanner struct {
 	ScanOpts
 	res    scanResult
 	resIdx int
-	cur    string
 	err    error
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -63,6 +63,7 @@ type scanner struct {
 	Client
 	ScanOpts
 	res []string
+	resIdx int
 	cur string
 	err error
 }
@@ -86,12 +87,12 @@ func (s *scanner) Next(res *string) bool {
 			return false
 		}
 
-		if len(s.res) > 0 {
-			*res, s.res = s.res[0], s.res[1:]
-			if *res == "" {
-				continue
+		for s.resIdx < len(s.res) {
+			*res = s.res[s.resIdx]
+			s.resIdx++
+			if *res != "" {
+				return true
 			}
-			return true
 		}
 
 		if s.cur == "0" && s.res != nil {
@@ -109,6 +110,7 @@ func (s *scanner) Next(res *string) bool {
 		}
 		s.cur = string(parts[0].([]byte))
 		s.res = s.res[:0]
+		s.resIdx = 0
 		for _, res := range parts[1].([]interface{}) {
 			s.res = append(s.res, string(res.([]byte)))
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -38,7 +38,7 @@ type ScanOpts struct {
 
 func (o ScanOpts) cmd(rcv interface{}, cursor string) CmdAction {
 	cmdStr := strings.ToUpper(o.Command)
-	var args []string
+	args := make([]string, 0, 4)
 	if cmdStr != "SCAN" {
 		args = append(args, o.Key)
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -3,9 +3,10 @@ package radix
 import (
 	"bufio"
 	"errors"
-	"github.com/mediocregopher/radix/v3/resp/resp2"
 	"strconv"
 	"strings"
+
+	"github.com/mediocregopher/radix/v3/resp/resp2"
 )
 
 // Scanner is used to iterate through the results of a SCAN call (or HSCAN,
@@ -64,10 +65,10 @@ var ScanAllKeys = ScanOpts{
 type scanner struct {
 	Client
 	ScanOpts
-	res scanResult
+	res    scanResult
 	resIdx int
-	cur string
-	err error
+	cur    string
+	err    error
 }
 
 // NewScanner creates a new Scanner instance which will iterate over the redis

--- a/scanner.go
+++ b/scanner.go
@@ -40,7 +40,7 @@ type ScanOpts struct {
 
 func (o ScanOpts) cmd(rcv interface{}, cursor string) CmdAction {
 	cmdStr := strings.ToUpper(o.Command)
-	args := make([]string, 0, 4)
+	args := make([]string, 0, 6)
 	if cmdStr != "SCAN" {
 		args = append(args, o.Key)
 	}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -71,10 +71,8 @@ func BenchmarkScanner(b *B) {
 
 	// Make a random dataset
 	prefix := randStr()
-	fullMap := map[string]bool{}
 	for i := 0; i < total; i++ {
 		key := prefix + ":" + strconv.Itoa(i)
-		fullMap[key] = true
 		require.Nil(b, c.Do(Cmd(nil, "SET", key, "1")))
 	}
 

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -129,7 +129,7 @@ func (s *sentinelStub) switchPrimary(newPrimAddr string, newSecAddrs ...string) 
 
 func TestSentinel(t *T) {
 	stub := newSentinelStub(
-		"127.0.0.1:6379", // primAddr
+		"127.0.0.1:6379",                                                                // primAddr
 		[]string{"127.0.0.2:6379", "127.0.0.3:6379"},                                    //secAddrs
 		[]string{"127.0.0.1:26379", "127.0.0.2:26379", "[0:0:0:0:0:ffff:7f00:3]:26379"}, // sentAddrs
 	)


### PR DESCRIPTION
This optimizes the performance of `Scanner` by avoiding allocations and manually unmarshalling the scan results into correctly typed values.

I also added a benchmark to measure the improvements.

Benchmark:

```
name       old time/op    new time/op    delta
Scanner-8    42.0ms ± 1%    32.2ms ± 1%  -23.32%  (p=0.008 n=5+5)

name       old alloc/op   new alloc/op   delta
Scanner-8    2.70MB ± 0%    0.55MB ± 0%  -79.65%  (p=0.008 n=5+5)

name       old allocs/op  new allocs/op  delta
Scanner-8     65.8k ± 0%     12.0k ± 0%  -81.83%  (p=0.008 n=5+5)
```