### PR TITLE
Update Travis for Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: go
 go:
-  - "1.11"
-  - "1.10.7"
+  - "1.11.x"
+  - "1.12.x"
 
 services:
   - redis-server


### PR DESCRIPTION
Also moves to `.x` for the patch version, which is always the latest patch version.