### PR TITLE
Avoid allocating in Conn.NetConn

### DIFF
--- a/radix.go
+++ b/radix.go
@@ -197,24 +197,6 @@ type Conn interface {
 	NetConn() net.Conn
 }
 
-// a wrapper around net.Conn which prevents Read, Write, and Close from being
-// called
-type connLimited struct {
-	net.Conn
-}
-
-func (cl connLimited) Read(b []byte) (int, error) {
-	return 0, errors.New("Read not allowed to be called on net.Conn returned from radix")
-}
-
-func (cl connLimited) Write(b []byte) (int, error) {
-	return 0, errors.New("Write not allowed to be called on net.Conn returned from radix")
-}
-
-func (cl connLimited) Close() error {
-	return errors.New("Close not allowed to be called on net.Conn returned from radix")
-}
-
 type connWrap struct {
 	net.Conn
 	brw *bufio.ReadWriter
@@ -246,7 +228,7 @@ func (cw *connWrap) Decode(u resp.Unmarshaler) error {
 }
 
 func (cw *connWrap) NetConn() net.Conn {
-	return connLimited{cw.Conn}
+	return cw.Conn
 }
 
 // ConnFunc is a function which returns an initialized, ready-to-be-used Conn.


### PR DESCRIPTION
I noticed this in #84. The only (non-stub) implementation of
Conn.NetConn currently wraps the net.Conn in a connLimited
which prevents calls to Read, Write and Close, but also causes
an allocation.

As noted in the issue, this is unnecessary and goes against the
general way of handling these kind of restrictions in the package
which is just documenting what is not allowed instead of trying to
prevent the user from doing stupid things. They will always find a
way anyway, so no need to be too preventive / defensive here.

Since the Conn.NetConn documentation already forbis calling these
methods we can just remove the wrapping altogether and avoid the
allocation.

No new benchmark since this is not an important change and we got
some numbers in #84.

Updates #84