### PR TITLE
Reduce total memory allocated and number of allocations in PubSub processing

### DIFF
--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -314,6 +314,9 @@ func TestPubSubChaotic(t *T) {
 
 func BenchmarkPubSub(b *B) {
 	c, pubC := PubSub(dial()), dial()
+	defer c.Close()
+	defer pubC.Close()
+
 	msg := string(randStr())
 	msgCh := make(chan PubSubMessage, 1)
 	require.Nil(b, c.Subscribe(msgCh, "benchmark"))

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -312,6 +312,22 @@ func TestPubSubChaotic(t *T) {
 	}
 }
 
+func BenchmarkPubSub(b *B) {
+	c, pubC := PubSub(dial()), dial()
+	msg := string(randStr())
+	msgCh := make(chan PubSubMessage, 1)
+	require.Nil(b, c.Subscribe(msgCh, "benchmark"))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if err := pubC.Do(Cmd(nil, "PUBLISH", "benchmark", msg)); err != nil {
+			b.Fatal(err)
+		}
+		<-msgCh
+	}
+}
+
 func ExamplePubSub() {
 	// Create a normal redis connection
 	conn, err := Dial("tcp", "127.0.0.1:6379")


### PR DESCRIPTION
Also includes a new benchmark for simple PubSub

```
name      old time/op    new time/op    delta
PubSub-8    51.9µs ±10%    46.0µs ±14%  -11.24%  (p=0.002 n=10+10)

name      old alloc/op   new alloc/op   delta
PubSub-8    4.73kB ± 0%    0.37kB ± 0%  -92.18%  (p=0.000 n=10+10)

name      old allocs/op  new allocs/op  delta
PubSub-8      17.0 ± 0%      10.0 ± 0%  -41.18%  (p=0.000 n=10+10)
```

Updates #91