### PR TITLE
Avoid allocating a string for each struct field when unmarshalling

### DIFF
--- a/resp/resp2/bench_test.go
+++ b/resp/resp2/bench_test.go
@@ -38,3 +38,28 @@ func BenchmarkIntUnmarshalRESP(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkAnyUnmarshalRESP(b *testing.B) {
+	b.Run("Struct", func(b *testing.B) {
+		b.ReportAllocs()
+
+		const input = "*8\r\n" +
+			"$3\r\nFoo\r\n" + ":1\r\n" +
+			"$3\r\nBAZ\r\n" + "$1\r\n3\r\n" +
+			"$3\r\nBoz\r\n" + ":5\r\n" +
+			"$3\r\nBiz\r\n" + "$2\r\n10\r\n"
+
+		var sr strings.Reader
+		br := bufio.NewReader(&sr)
+
+		for i := 0; i < b.N; i++ {
+			sr.Reset(input)
+			br.Reset(&sr)
+
+			var s testStructA
+			if err := (Any{I: &s}).UnmarshalRESP(br); err != nil {
+				b.Fatalf("failed to unmarshal %q: %s", input, err)
+			}
+		}
+	})
+}

--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -905,14 +905,15 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 		}
 
 		structFields := getStructFields(v.Type())
+		var field BulkStringBytes
+
 		for i := 0; i < size; i += 2 {
-			var bs BulkString
-			if err := bs.UnmarshalRESP(br); err != nil {
+			if err := field.UnmarshalRESP(br); err != nil {
 				return err
 			}
 
 			var vv reflect.Value
-			structField, ok := structFields[bs.S]
+			structField, ok := structFields[string(field.B)] // no allocation, since Go 1.3
 			if ok {
 				vv = getStructField(v, structField.indices)
 			}


### PR DESCRIPTION
This reuses the allocated memory for the struct field by switchting from `BulkString` to `BulkStringBytes` and using the `map[string([]byte)]` optimization introduced in Go 1.3.

```
name                       old time/op    new time/op    delta
AnyUnmarshalRESP/Struct-8    1.68µs ± 1%    1.35µs ± 1%  -19.73%  (p=0.000 n=9+8)

name                       old alloc/op   new alloc/op   delta
AnyUnmarshalRESP/Struct-8      112B ± 0%       96B ± 0%  -14.29%  (p=0.000 n=10+10)

name                       old allocs/op  new allocs/op  delta
AnyUnmarshalRESP/Struct-8      7.00 ± 0%      4.00 ± 0%  -42.86%  (p=0.000 n=10+10)
```