### PR TITLE
Reuse reflect.Value instances when unmarshalling maps

### DIFF
--- a/resp/resp2/bench_test.go
+++ b/resp/resp2/bench_test.go
@@ -40,6 +40,29 @@ func BenchmarkIntUnmarshalRESP(b *testing.B) {
 }
 
 func BenchmarkAnyUnmarshalRESP(b *testing.B) {
+	b.Run("Map", func(b *testing.B) {
+		b.ReportAllocs()
+
+		const input = "*8\r\n" +
+			"$3\r\nFoo\r\n" + "$1\r\n1\r\n" +
+			"$3\r\nBAZ\r\n" + "$2\r\n22\r\n" +
+			"$3\r\nBoz\r\n" + "$4\r\n4444\r\n" +
+			"$3\r\nBiz\r\n" + "$8\r\n88888888\r\n"
+
+		var sr strings.Reader
+		br := bufio.NewReader(&sr)
+
+		for i := 0; i < b.N; i++ {
+			sr.Reset(input)
+			br.Reset(&sr)
+
+			var m map[string]string
+			if err := (Any{I: &m}).UnmarshalRESP(br); err != nil {
+				b.Fatalf("failed to unmarshal %q: %s", input, err)
+			}
+		}
+	})
+
 	b.Run("Struct", func(b *testing.B) {
 		b.ReportAllocs()
 

--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -885,12 +885,12 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 		}
 
 		var kvs reflect.Value
-		if canShareReflectValue(v.Type().Key()) {
+		if size > 0 && canShareReflectValue(v.Type().Key()) {
 			kvs = reflect.New(v.Type().Key())
 		}
 
 		var vvs reflect.Value
-		if canShareReflectValue(v.Type().Elem()) {
+		if size > 0 && canShareReflectValue(v.Type().Elem()) {
 			vvs = reflect.New(v.Type().Elem())
 		}
 

--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -884,13 +884,29 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 			v.Set(reflect.MakeMapWithSize(v.Type(), size/2))
 		}
 
+		var kvs reflect.Value
+		if canShareReflectValue(v.Type().Key()) {
+			kvs = reflect.New(v.Type().Key())
+		}
+
+		var vvs reflect.Value
+		if canShareReflectValue(v.Type().Elem()) {
+			vvs = reflect.New(v.Type().Elem())
+		}
+
 		for i := 0; i < size; i += 2 {
-			kv := reflect.New(v.Type().Key())
+			kv := kvs
+			if !kv.IsValid() {
+				kv = reflect.New(v.Type().Key())
+			}
 			if err := (Any{I: kv.Interface()}).UnmarshalRESP(br); err != nil {
 				return err
 			}
 
-			vv := reflect.New(v.Type().Elem())
+			vv := vvs
+			if !vv.IsValid() {
+				vv = reflect.New(v.Type().Elem())
+			}
 			if err := (Any{I: vv.Interface()}).UnmarshalRESP(br); err != nil {
 				return err
 			}
@@ -935,6 +951,31 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 
 	default:
 		return fmt.Errorf("cannot decode redis array into %v", v.Type())
+	}
+}
+
+func canShareReflectValue(ty reflect.Type) bool {
+	switch ty.Kind() {
+	case reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.String:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/resp/resp2/resp_test.go
+++ b/resp/resp2/resp_test.go
@@ -419,6 +419,17 @@ func TestAnyUnmarshal(t *T) {
 			},
 			{in: "*2\r\n:1\r\n:2\r\n", out: map[string]string{"1": "2"}},
 			{in: "*2\r\n*2\r\n+foo\r\n+bar\r\n*1\r\n+baz\r\n", out: nil},
+			{
+				in: "*6\r\n" +
+					"$3\r\none\r\n" + "*2\r\n$1\r\n!\r\n$1\r\n1\r\n" +
+					"$3\r\ntwo\r\n" + "*2\r\n$2\r\n!!\r\n$1\r\n2\r\n" +
+					"$5\r\nthree\r\n" + "*2\r\n$3\r\n!!!\r\n$1\r\n3\r\n",
+				out: map[string]map[string]int{
+					"one":   {"!": 1},
+					"two":   {"!!": 2},
+					"three": {"!!!": 3},
+				},
+			},
 
 			// Arrays (structs)
 			{


### PR DESCRIPTION
Unmarshalling maps currently requires creating a new instance of both the key and value types for each key and value, meaning there are at least two allocations per key-value pair, even if the types themselves wouldn't require allocations (e.g. numbers).

For non-pointer values that don't contain pointers or where the pointed to values can't be changed (strings), we can reuse the `reflect.Value` instances to avoid allocating new `reflect.Value`s for each value instance that we need.

This change adds a check for these kind of values (basically all built in numeric types, booleans and strings) and reuses the `reflect.Value` instances for these if possible.

With this for a map of size `n`, where `n > 0` and both key and value can share their `reflect.Value` instance, the number of allocations is reduced by `2*n - 2`.

```
name                    old time/op    new time/op    delta
AnyUnmarshalRESP/Map-8    2.07µs ± 1%    1.76µs ± 7%  -14.69%  (p=0.000 n=20+18)

name                    old alloc/op   new alloc/op   delta
AnyUnmarshalRESP/Map-8      504B ± 0%      408B ± 0%  -19.05%  (p=0.000 n=20+20)

name                    old allocs/op  new allocs/op  delta
AnyUnmarshalRESP/Map-8      18.0 ± 0%      12.0 ± 0%  -33.33%  (p=0.000 n=20+20)
```