### PR TITLE
Fix panic when having giving an untyped nil value to FlatCmd

### DIFF
--- a/action_test.go
+++ b/action_test.go
@@ -97,6 +97,20 @@ func TestFlatCmdAction(t *T) {
 	assert.Equal(t, m, got)
 }
 
+func TestFlatCmdActionNil(t *T) {
+	c := dial()
+	defer c.Close()
+
+	key := randStr()
+	hashKey := randStr()
+
+	require.Nil(t, c.Do(FlatCmd(nil, "HMSET", key, hashKey, nil)))
+
+	var nilVal MaybeNil
+	require.Nil(t, c.Do(Cmd(&nilVal, "HGET", key, hashKey)))
+	require.False(t, nilVal.Nil)
+}
+
 func TestEvalAction(t *T) {
 	getSet := NewEvalScript(1, `
 		local prev = redis.call("GET", KEYS[1])

--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -408,6 +408,10 @@ var (
 )
 
 func numElems(vv reflect.Value) int {
+	if !vv.IsValid() {
+		return 1
+	}
+
 	tt := vv.Type()
 	switch {
 	case tt.Implements(lenReaderT):


### PR DESCRIPTION
This fixes a panic in `(resp2.Any).NumElems` when one of the arguments is or contains an untyped nil value.  