### PR TITLE
[WIP] Add a feature to get metric by giving Trace struct

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -312,7 +312,9 @@ func (c *Cluster) sync(p Client) error {
 	}
 
 	if reflect.DeepEqual(c.topo.Map(), tt.Map()) {
-		go c.co.ct.TopoChange()
+		if c.co.ct.TopoChange != nil {
+			go c.co.ct.TopoChange()
+		}
 	}
 
 	// this is a big bit of code to totally lockdown the cluster for, but at the
@@ -449,7 +451,9 @@ func (c *Cluster) doInner(a Action, addr, key string, ask bool, attempts int) er
 	// Also, even if the Action isn't a ClusterCanRetryAction we want a MOVED to
 	// prompt a Sync
 	if moved {
-		go c.co.ct.MovedRespond()
+		if c.co.ct.MovedRespond != nil {
+			go c.co.ct.MovedRespond()
+		}
 		if serr := c.Sync(); serr != nil {
 			return serr
 		}


### PR DESCRIPTION
Hi,
This is a way better, more human readable approach. User can create trace functions like below.
```
ct := radix.ClusterTrace{
	TopoChange: func() {
		fmt.Println("topology changed")
	},
	MovedRespond: func() {
		fmt.Println("moved!")
	},
}
pt := radix.PoolTrace{
	ConnectDone: func(addr string, err error) {
		if err != nil {
			fmt.Println("err")
		} else {
			fmt.Println(addr)
		}
	},
}
```