### PR TITLE
Add a feature to get informations in Cluster/Pool by using Trace struct

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -134,7 +134,6 @@ func NewCluster(clusterAddrs []string, opts ...ClusterOpt) (*Cluster, error) {
 	defaultClusterOpts := []ClusterOpt{
 		ClusterPoolFunc(DefaultClientFunc),
 		ClusterSyncEvery(5 * time.Second),
-		ClusterWithTrace(trace.ClusterTrace{}),
 	}
 
 	for _, opt := range append(defaultClusterOpts, opts...) {

--- a/cluster.go
+++ b/cluster.go
@@ -460,7 +460,7 @@ func (c *Cluster) Do(a Action) error {
 
 func (c *Cluster) traceRedirected(addr, key string, moved, ask bool, attempts int) {
 	if c.co.ct.Redirected != nil {
-		c.co.ct.Redirected(trace.ClusterRedirected{Addr: addr, Key: key, Moved: moved, Ask: ask, RemainRedirectCount: attempts})
+		c.co.ct.Redirected(trace.ClusterRedirected{Addr: addr, Key: key, Moved: moved, Ask: ask, RedirectCount: doAttempts - attempts})
 	}
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -461,18 +461,15 @@ func (c *Cluster) doInner(a Action, addr, key string, ask bool, attempts int) er
 	thisA := a
 	if ask {
 		thisA = WithConn(key, func(conn Conn) error {
-			err = askConn{conn}.Do(a)
-			c.traceGotResponse(addr, key, attempts, err)
-			return err
+			return askConn{conn}.Do(a)
 		})
 	}
 
-	if err = p.Do(thisA); err == nil {
-		c.traceGotResponse(addr, key, attempts, nil)
+	err = p.Do(thisA)
+	c.traceGotResponse(addr, key, attempts, err)
+	if err == nil {
 		return nil
 	}
-
-	c.traceGotResponse(addr, key, attempts, err)
 
 	// if the error was a MOVED or ASK we can potentially retry
 	msg := err.Error()

--- a/pool.go
+++ b/pool.go
@@ -347,8 +347,8 @@ func (p *Pool) err(err error) {
 func (p *Pool) traceConnectDone(connectTime time.Duration, reason trace.PoolConnectReason, err error) {
 	if p.opts.pt.ConnectDone != nil {
 		p.opts.pt.ConnectDone(trace.PoolConnectDone{
-			PoolInfo:     trace.PoolInfo{Addr: p.addr},
-			PoolConnInfo: trace.PoolConnInfo{PoolSize: p.size, BufferSize: p.opts.overflowSize, AvailCount: len(p.pool)},
+			PoolHostInfo: trace.PoolHostInfo{Network: p.network, Addr: p.addr},
+			PoolInfo:     trace.PoolInfo{PoolSize: p.size, BufferSize: p.opts.overflowSize, AvailCount: len(p.pool)},
 			Reason:       reason,
 			ConnectTime:  connectTime,
 			Err:          err,
@@ -359,8 +359,8 @@ func (p *Pool) traceConnectDone(connectTime time.Duration, reason trace.PoolConn
 func (p *Pool) traceConnClosed(reason trace.PoolConnClosedReason) {
 	if p.opts.pt.ConnClosed != nil {
 		p.opts.pt.ConnClosed(trace.PoolConnClosed{
-			PoolInfo:     trace.PoolInfo{Addr: p.addr},
-			PoolConnInfo: trace.PoolConnInfo{PoolSize: p.size, BufferSize: p.opts.overflowSize, AvailCount: len(p.pool)},
+			PoolHostInfo: trace.PoolHostInfo{Network: p.network, Addr: p.addr},
+			PoolInfo:     trace.PoolInfo{PoolSize: p.size, BufferSize: p.opts.overflowSize, AvailCount: len(p.pool)},
 			Reason:       reason,
 		})
 	}

--- a/pool.go
+++ b/pool.go
@@ -271,7 +271,6 @@ func NewPool(network, addr string, size int, opts ...PoolOpt) (*Pool, error) {
 		PoolPipelineConcurrency(size),
 		// NOTE if 150us is changed the benchmarks need to be updated too
 		PoolPipelineWindow(150*time.Microsecond, 0),
-		PoolWithTrace(trace.PoolTrace{}),
 	}
 
 	for _, opt := range append(defaultPoolOpts, opts...) {

--- a/pool.go
+++ b/pool.go
@@ -513,9 +513,7 @@ func (p *Pool) get() (*ioErrConn, error) {
 	// at this point everything is unlocked and the conn needs to be created.
 	// newConn will handle checking if the pool has been closed since the inner
 	// was called.
-	ioc, err = p.newConn(false, "BUFFER")
-
-	return ioc, err
+	return p.newConn(false, "BUFFER")
 }
 
 func (p *Pool) put(ioc *ioErrConn) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -57,18 +57,18 @@ func TestPool(t *T) {
 	t.Run("onEmptyErrAfter", func(t *T) { do(PoolOnEmptyErrAfter(1 * time.Second)) })
 
 	t.Run("withTrace", func(t *T) {
-		var ConnectDoneCount int
-		var ConnClosedCount int
+		var connectDoneCount int
+		var connClosedCount int
 		pt := trace.PoolTrace{
 			ConnectDone: func(done trace.PoolConnectDone) {
-				ConnectDoneCount++
+				connectDoneCount++
 			},
 			ConnClosed: func(closed trace.PoolConnClosed) {
-				ConnClosedCount++
+				connClosedCount++
 			},
 		}
 		do(PoolWithTrace(pt))
-		if ConnectDoneCount != ConnClosedCount {
+		if connectDoneCount != connClosedCount {
 			t.Fail()
 		}
 	})

--- a/pool_test.go
+++ b/pool_test.go
@@ -119,7 +119,7 @@ func TestPoolOnFull(t *T) {
 		defer pool.Close()
 		assert.Equal(t, 1, len(pool.pool))
 
-		spc, err := pool.newConn(false)
+		spc, err := pool.newConn(false, "TEST")
 		assert.NoError(t, err)
 		pool.put(spc)
 		assert.Equal(t, 1, len(pool.pool))
@@ -131,13 +131,13 @@ func TestPoolOnFull(t *T) {
 		assert.Equal(t, 1, len(pool.pool))
 
 		// putting a conn should overflow
-		spc, err := pool.newConn(false)
+		spc, err := pool.newConn(false, "TEST")
 		assert.NoError(t, err)
 		pool.put(spc)
 		assert.Equal(t, 2, len(pool.pool))
 
 		// another shouldn't, overflow is full
-		spc, err = pool.newConn(false)
+		spc, err = pool.newConn(false, "TEST")
 		assert.NoError(t, err)
 		pool.put(spc)
 		assert.Equal(t, 2, len(pool.pool))
@@ -150,7 +150,7 @@ func TestPoolOnFull(t *T) {
 		assert.Equal(t, 1, len(pool.pool))
 
 		// if both are full then drain should remove the overflow one
-		spc, err = pool.newConn(false)
+		spc, err = pool.newConn(false, "TEST")
 		assert.NoError(t, err)
 		pool.put(spc)
 		assert.Equal(t, 2, len(pool.pool))

--- a/pool_test.go
+++ b/pool_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mediocregopher/radix/v3/trace"
 )
 
 func testPool(size int, opts ...PoolOpt) *Pool {
@@ -54,6 +56,22 @@ func TestPool(t *T) {
 	//t.Run("onEmptyErr", func(t *T) { do(PoolOnEmptyErrAfter(0)) })
 	t.Run("onEmptyErrAfter", func(t *T) { do(PoolOnEmptyErrAfter(1 * time.Second)) })
 
+	t.Run("withTrace", func(t *T) {
+		var ConnectDoneCount int
+		var ConnClosedCount int
+		pt := trace.PoolTrace{
+			ConnectDone: func(done trace.PoolConnectDone) {
+				ConnectDoneCount++
+			},
+			ConnClosed: func(closed trace.PoolConnClosed) {
+				ConnClosedCount++
+			},
+		}
+		do(PoolWithTrace(pt))
+		if ConnectDoneCount != ConnClosedCount {
+			t.Fail()
+		}
+	})
 }
 
 // Test all the different OnEmpty behaviors

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,0 +1,68 @@
+package trace
+
+import (
+	"time"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+type ClusterTrace struct {
+	// TopoChanged is called when the cluster's topology changed.
+	TopoChanged func(ClusterTopoChanged)
+	// GotResponse is called after the radix.Do executed.
+	GotResponse func(ClusterGotResponse)
+}
+
+type ClusterNodeInfo struct {
+	Addr      string
+	Slots     [][2]uint16
+	IsPrimary bool
+}
+
+type ClusterTopoChanged struct {
+	Added   []ClusterNodeInfo
+	Removed []ClusterNodeInfo
+}
+
+type ClusterGotResponse struct {
+	Addr       string
+	Key        string
+	RetryCount int
+	Err        error
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type PoolTrace struct {
+	// ConnectDone is called when a new connection's Dial completes. The provided
+	// Err indicates whether the connection successfully completed.
+	ConnectDone func(PoolConnectDone)
+	// ConnClosed is called before closing the connection.
+	ConnClosed func(PoolConnClosed)
+}
+
+type PoolInfo struct {
+	Addr string
+}
+
+type PoolConnInfo struct {
+	PoolSize   int
+	BufferSize int
+	AvailCount int
+}
+
+type PoolConnectDone struct {
+	PoolInfo
+	PoolConnInfo
+	Reason      string
+	ConnectTime time.Duration
+	Err         error
+}
+
+type PoolConnClosed struct {
+	PoolInfo
+	PoolConnInfo
+	Reason string
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -1,3 +1,4 @@
+// Disclaimer: Note that Package trace is not stable yet and is subject to change.
 package trace
 
 import (

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -55,7 +55,7 @@ type PoolConnInfo struct {
 type PoolConnectDone struct {
 	PoolInfo
 	PoolConnInfo
-	Reason      string
+	Reason      PoolConnectReason
 	ConnectTime time.Duration
 	Err         error
 }
@@ -63,7 +63,23 @@ type PoolConnectDone struct {
 type PoolConnClosed struct {
 	PoolInfo
 	PoolConnInfo
-	Reason string
+	Reason PoolConnClosedReason
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+type PoolConnectReason string
+type PoolConnClosedReason string
+
+const (
+	PoolConnectReasonInitialize PoolConnectReason = "initialize"
+	PoolConnectReasonRefill     PoolConnectReason = "refill"
+	PoolConnectReasonBuffer     PoolConnectReason = "buffer"
+)
+
+const (
+	PoolConnClosedReasonPoolClosing PoolConnClosedReason = "pool is closing"
+	PoolConnClosedReasonPoolClosed  PoolConnClosedReason = "pool closed"
+	PoolConnClosedReasonBufferDrain PoolConnClosedReason = "buffer drained"
+	PoolConnClosedReasonPoolIsFull  PoolConnClosedReason = "pool is full"
+)

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -22,6 +22,7 @@ type ClusterNodeInfo struct {
 type ClusterTopoChanged struct {
 	Added   []ClusterNodeInfo
 	Removed []ClusterNodeInfo
+	Changed []ClusterNodeInfo
 }
 
 type ClusterRedirected struct {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -26,10 +26,10 @@ type ClusterTopoChanged struct {
 }
 
 type ClusterRedirected struct {
-	Addr                string
-	Key                 string
-	Moved, Ask          bool
-	RemainRedirectCount int
+	Addr          string
+	Key           string
+	Moved, Ask    bool
+	RedirectCount int
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -9,8 +9,8 @@ import (
 type ClusterTrace struct {
 	// TopoChanged is called when the cluster's topology changed.
 	TopoChanged func(ClusterTopoChanged)
-	// GotResponse is called after the radix.Do executed.
-	GotResponse func(ClusterGotResponse)
+	// Redirected is called when radix.Do responded 'MOVED' or 'ASKED'.
+	Redirected func(ClusterRedirected)
 }
 
 type ClusterNodeInfo struct {
@@ -24,11 +24,11 @@ type ClusterTopoChanged struct {
 	Removed []ClusterNodeInfo
 }
 
-type ClusterGotResponse struct {
-	Addr       string
-	Key        string
-	RetryCount int
-	Err        error
+type ClusterRedirected struct {
+	Addr                string
+	Key                 string
+	Moved, Ask          bool
+	RemainRedirectCount int
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -42,27 +42,28 @@ type PoolTrace struct {
 	ConnClosed func(PoolConnClosed)
 }
 
-type PoolInfo struct {
-	Addr string
+type PoolHostInfo struct {
+	Network string
+	Addr    string
 }
 
-type PoolConnInfo struct {
+type PoolInfo struct {
 	PoolSize   int
 	BufferSize int
 	AvailCount int
 }
 
 type PoolConnectDone struct {
+	PoolHostInfo
 	PoolInfo
-	PoolConnInfo
 	Reason      PoolConnectReason
 	ConnectTime time.Duration
 	Err         error
 }
 
 type PoolConnClosed struct {
+	PoolHostInfo
 	PoolInfo
-	PoolConnInfo
 	Reason PoolConnClosedReason
 }
 


### PR DESCRIPTION
Hi, I've uploaded new PR and improve and clean up the codes little bit. I'm not sure I fixed this PR clearly what you mentioned before.

This PR allows people to get callbacks for a specific time of the event (which is described in trace package). I made simple Trace struct and callback events for Cluster, Pool respectively for the first version.

Could you please check whether the callback events propagate at the right time of the event and review this PR?

Can be improved...
  - [x] Make static reason values (REFILL, BUFFERED, etc) to a constant value
  - [x] Find a better way to find added, removed cluster nodes when topology changed
  - Give more detailed descriptions for the trace package (Sorry for my poor English in docstring)
  - Add TCs

Any suggestions welcome!

ref: https://github.com/mediocregopher/radix/issues/93