### PR TITLE
Remove a wrong comment on PubSubMessage

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -21,8 +21,7 @@ type PubSubMessage struct {
 	Message []byte
 }
 
-// MarshalRESP implements the Marshaler interface. It will assume the
-// PubSubMessage is a PMESSAGE if Pattern is non-empty.
+// MarshalRESP implements the Marshaler interface.
 func (m PubSubMessage) MarshalRESP(w io.Writer) error {
 	var err error
 	marshal := func(m resp.Marshaler) {


### PR DESCRIPTION
The [comment on MarshalRESP](https://github.com/mediocregopher/radix/blob/master/pubsub.go#L24-L25) says that a message with a pattern will be assumed to be a PMESSAGE, but there is [no such logic](https://github.com/mediocregopher/radix/blob/master/pubsub.go#L34-L43).