### PR TITLE
Add InitCompleted trace and get avail count for specified events

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -61,6 +61,7 @@ func TestPool(t *T) {
 		var connCreatedCount int
 		var connClosedCount int
 		var doCompletedCount uint32
+		var initializedAvailCount int
 		pt := trace.PoolTrace{
 			ConnCreated: func(done trace.PoolConnCreated) {
 				connCreatedCount++
@@ -71,8 +72,14 @@ func TestPool(t *T) {
 			DoCompleted: func(completed trace.PoolDoCompleted) {
 				atomic.AddUint32(&doCompletedCount, 1)
 			},
+			InitCompleted: func(completed trace.PoolInitCompleted) {
+				initializedAvailCount = completed.AvailCount
+			},
 		}
 		do(PoolWithTrace(pt))
+		if initializedAvailCount != 10 {
+			t.Fail()
+		}
 		if connCreatedCount != connClosedCount {
 			t.Fail()
 		}

--- a/trace/pool.go
+++ b/trace/pool.go
@@ -19,6 +19,9 @@ type PoolTrace struct {
 	// for manipulating variables in DoCompleted callback since DoComplete
 	// function can be called in many go-routines.
 	DoCompleted func(PoolDoCompleted)
+
+	// InitCompleted is called after pool fills its connections
+	InitCompleted func(PoolInitCompleted)
 }
 
 // PoolCommon contains information which is passed into all Pool-related
@@ -31,10 +34,6 @@ type PoolCommon struct {
 	// PoolSize and BufferSize indicate the Pool size and buffer size that the
 	// Pool was initialized with.
 	PoolSize, BufferSize int
-
-	// AvailCount indicates the total number of connections the Pool is holding
-	// on to which are available for usage at the moment the trace occurs.
-	AvailCount int
 }
 
 // PoolConnCreatedReason enumerates all the different reasons a connection might
@@ -96,16 +95,39 @@ const (
 type PoolConnClosed struct {
 	PoolCommon
 
+	// AvailCount indicates the total number of connections the Pool is holding
+	// on to which are available for usage at the moment the trace occurs.
+	AvailCount int
+
 	// The reason the connection was closed.
 	Reason PoolConnClosedReason
 }
 
+// PoolDoCompleted is passed into the PoolTrace.DoCompleted callback whenever Pool finished to run
+// Do function.
 type PoolDoCompleted struct {
 	PoolCommon
+
+	// AvailCount indicates the total number of connections the Pool is holding
+	// on to which are available for usage at the moment the trace occurs.
+	AvailCount int
 
 	// How long it took to send command.
 	ElapsedTime time.Duration
 
 	// This is the error returned from redis.
 	Err error
+}
+
+// PoolInitCompleted is passed into the PoolTrace.InitCompleted callback whenever Pool initialized.
+// This must be called once.
+type PoolInitCompleted struct {
+	PoolCommon
+
+	// AvailCount indicates the total number of connections the Pool is holding
+	// on to which are available for usage at the moment the trace occurs.
+	AvailCount int
+
+	// How long it took to fill all connections.
+	ElapsedTime time.Duration
 }


### PR DESCRIPTION
Hi, I've changed for getting (quite) correct value for available connection count in Pool. I added a new trace function named `InitCompleted` which invokes right after `Pool` fills all connections when initializing.

And then, We can get the correct value for available connection count for three cases. First, `initCompleted` will return `AvailCount` which is the same size as the `Pool`. Second, `DoComplete` will callback right after returning the connection into the `Pool` so we could get the exact value. Third, `ConnClosed`. This also callback after we get the connection to be closed, therefore we could get exact connection count as well.