### PR TITLE
switch to use xerrors temporarily

### DIFF
--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -2,11 +2,12 @@ package bench
 
 import (
 	"context"
-	"errors"
 	"runtime"
 	"strings"
 	. "testing"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	redigo "github.com/gomodule/redigo/redis"
 	redispipe "github.com/joomcode/redispipe/redis"

--- a/bench/go.sum
+++ b/bench/go.sum
@@ -16,3 +16,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/cluster.go
+++ b/cluster.go
@@ -1,12 +1,12 @@
 package radix
 
 import (
-	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/resp/resp2"
@@ -183,7 +183,7 @@ func assertKeysSlot(keys []string) error {
 		if !ok {
 			ok = true
 		} else if slot != thisSlot {
-			return fmt.Errorf("keys %q and %q do not belong to the same slot", prevKey, key)
+			return errors.Errorf("keys %q and %q do not belong to the same slot", prevKey, key)
 		}
 		prevKey = key
 		slot = thisSlot
@@ -356,7 +356,7 @@ func (c *Cluster) sync(p Client) error {
 	for _, t := range tt {
 		// call pool just to ensure one exists for this addr
 		if _, err := c.pool(t.Addr); err != nil {
-			return fmt.Errorf("error connecting to %s: %s", t.Addr, err)
+			return errors.Errorf("error connecting to %s: %w", t.Addr, err)
 		}
 	}
 
@@ -515,7 +515,7 @@ func (c *Cluster) doInner(a Action, addr, key string, ask bool, attempts int) er
 
 	msgParts := strings.Split(msg, " ")
 	if len(msgParts) < 3 {
-		return fmt.Errorf("malformed MOVED/ASK error %q", msg)
+		return errors.Errorf("malformed MOVED/ASK error %q", msg)
 	}
 	addr = msgParts[2]
 

--- a/cluster_stub_test.go
+++ b/cluster_stub_test.go
@@ -1,13 +1,14 @@
 package radix
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	. "testing"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp/resp2"
 	"github.com/stretchr/testify/assert"
@@ -65,13 +66,13 @@ func (s *clusterNodeStub) withKey(key string, asking bool, fn func(clusterSlotSt
 	slot, ok := s.clusterDatasetStub.slots[slotI]
 	if !ok {
 		movedStub := s.clusterStub.stubForSlot(slotI)
-		return resp2.Error{E: fmt.Errorf("MOVED %d %s", slotI, movedStub.addr)}
+		return resp2.Error{E: errors.Errorf("MOVED %d %s", slotI, movedStub.addr)}
 
 	} else if _, ok := slot.kv[key]; !ok && slot.migrating != "" {
-		return resp2.Error{E: fmt.Errorf("ASK %d %s", slotI, slot.migrating)}
+		return resp2.Error{E: errors.Errorf("ASK %d %s", slotI, slot.migrating)}
 
 	} else if slot.importing != "" && !asking {
-		return resp2.Error{E: fmt.Errorf("MOVED %d %s", slotI, slot.importing)}
+		return resp2.Error{E: errors.Errorf("MOVED %d %s", slotI, slot.importing)}
 	}
 
 	return fn(slot)
@@ -149,7 +150,7 @@ func (s *clusterNodeStub) newConn() Conn {
 			return []interface{}{"0", []string{}}
 		}
 
-		return resp2.Error{E: fmt.Errorf("unknown command %#v", args)}
+		return resp2.Error{E: errors.Errorf("unknown command %#v", args)}
 	})
 }
 
@@ -236,7 +237,7 @@ func (scl *clusterStub) clientFunc() ClientFunc {
 				return s.newConn(), nil
 			}
 		}
-		return nil, fmt.Errorf("unknown addr: %q", addr)
+		return nil, errors.Errorf("unknown addr: %q", addr)
 	}
 }
 

--- a/cluster_topo.go
+++ b/cluster_topo.go
@@ -2,10 +2,11 @@ package radix
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"net"
 	"sort"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/resp/resp2"
@@ -190,7 +191,7 @@ func (tss *topoSlotSet) UnmarshalRESP(br *bufio.Reader) error {
 		if err := (resp2.Any{I: &nodeStrs}).UnmarshalRESP(br); err != nil {
 			return err
 		} else if len(nodeStrs) < 2 {
-			return fmt.Errorf("malformed node array: %#v", nodeStrs)
+			return errors.Errorf("malformed node array: %#v", nodeStrs)
 		}
 		ip, port := nodeStrs[0], nodeStrs[1]
 		var id string

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ require (
 	github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
 )

--- a/go.sum
+++ b/go.sum
@@ -6,3 +6,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
+golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/bytesutil/bytesutil.go
+++ b/internal/bytesutil/bytesutil.go
@@ -4,11 +4,12 @@ package bytesutil
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"sync"
+
+	errors "golang.org/x/xerrors"
 )
 
 // AnyIntToInt64 converts a value of any of Go's integer types (signed and unsigned) into a signed int64.
@@ -100,7 +101,7 @@ func ParseUint(b []byte) (uint64, error) {
 
 	for i, c := range b {
 		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("invalid character %c at position %d in parseUint", c, i)
+			return 0, errors.Errorf("invalid character %c at position %d in parseUint", c, i)
 		}
 
 		n *= 10
@@ -128,7 +129,7 @@ func BufferedBytesDelim(br *bufio.Reader) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	} else if len(b) < 2 || b[len(b)-2] != '\r' {
-		return nil, fmt.Errorf("malformed resp %q", b)
+		return nil, errors.Errorf("malformed resp %q", b)
 	}
 	return b[:len(b)-2], err
 }

--- a/pool.go
+++ b/pool.go
@@ -1,11 +1,12 @@
 package radix
 
 import (
-	"errors"
 	"io"
 	"net"
 	"sync"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/trace"

--- a/pubsub.go
+++ b/pubsub.go
@@ -3,11 +3,12 @@ package radix
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"io"
 	"net"
 	"sync"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/resp/resp2"

--- a/pubsub_stub.go
+++ b/pubsub_stub.go
@@ -1,11 +1,12 @@
 package radix
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"strings"
 	"sync"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/resp/resp2"

--- a/radix.go
+++ b/radix.go
@@ -133,12 +133,13 @@ package radix
 import (
 	"bufio"
 	"crypto/tls"
-	"errors"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 )

--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -10,15 +10,14 @@ import (
 	"bufio"
 	"bytes"
 	"encoding"
-	"errors"
-	"fmt"
 	"io"
 	"reflect"
 	"strconv"
 	"sync"
 
-	"github.com/mediocregopher/radix/v3/internal/bytesutil"
+	errors "golang.org/x/xerrors"
 
+	"github.com/mediocregopher/radix/v3/internal/bytesutil"
 	"github.com/mediocregopher/radix/v3/resp"
 )
 
@@ -78,7 +77,7 @@ func assertBufferedPrefix(br *bufio.Reader, pref prefix) error {
 	if err != nil {
 		return err
 	} else if !bytes.Equal(b, []byte(pref)) {
-		return fmt.Errorf("expected prefix %q, got %q", pref.String(), prefix(b).String())
+		return errors.Errorf("expected prefix %q, got %q", pref.String(), prefix(b).String())
 	}
 	_, err = br.Discard(len(pref))
 	return err
@@ -643,7 +642,7 @@ func (a Any) MarshalRESP(w io.Writer) error {
 		return a.marshalStruct(w, vv, false)
 
 	default:
-		return fmt.Errorf("could not marshal value of type %T", a.I)
+		return errors.Errorf("could not marshal value of type %T", a.I)
 	}
 
 	return err
@@ -785,7 +784,7 @@ func (a Any) UnmarshalRESP(br *bufio.Reader) error {
 		byteReaderPool.Put(reader)
 		return err
 	default:
-		return fmt.Errorf("unknown type prefix %q", b[0])
+		return errors.Errorf("unknown type prefix %q", b[0])
 	}
 }
 
@@ -863,7 +862,7 @@ func (a Any) unmarshalSingle(body io.Reader, n int) error {
 		err = ai.UnmarshalBinary(*scratch)
 		bytesutil.PutBytes(scratch)
 	default:
-		return fmt.Errorf("can't unmarshal into %T", a.I)
+		return errors.Errorf("can't unmarshal into %T", a.I)
 	}
 
 	return err
@@ -890,7 +889,7 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 	size := int(l)
 	v := reflect.ValueOf(a.I)
 	if v.Kind() != reflect.Ptr {
-		return fmt.Errorf("can't unmarshal into %T", a.I)
+		return errors.Errorf("can't unmarshal into %T", a.I)
 	}
 	v = reflect.Indirect(v)
 
@@ -988,7 +987,7 @@ func (a Any) unmarshalArray(br *bufio.Reader, l int64) error {
 		return nil
 
 	default:
-		return fmt.Errorf("cannot decode redis array into %v", v.Type())
+		return errors.Errorf("cannot decode redis array into %v", v.Type())
 	}
 }
 
@@ -1172,7 +1171,7 @@ func (rm *RawMessage) unmarshal(br *bufio.Reader) error {
 	case ErrorPrefix[0], SimpleStringPrefix[0], IntPrefix[0]:
 		return nil
 	default:
-		return fmt.Errorf("unknown type prefix %q", b[0])
+		return errors.Errorf("unknown type prefix %q", b[0])
 	}
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -2,9 +2,10 @@ package radix
 
 import (
 	"bufio"
-	"errors"
 	"strconv"
 	"strings"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp/resp2"
 )

--- a/sentinel.go
+++ b/sentinel.go
@@ -1,10 +1,11 @@
 package radix
 
 import (
-	"fmt"
 	"net"
 	"sync"
 	"time"
+
+	errors "golang.org/x/xerrors"
 )
 
 type sentinelOpts struct {
@@ -292,7 +293,7 @@ func (sc *Sentinel) Close() error {
 // cmd should be the command called which generated m
 func sentinelMtoAddr(m map[string]string, cmd string) (string, error) {
 	if m["ip"] == "" || m["port"] == "" {
-		return "", fmt.Errorf("malformed %s response", cmd)
+		return "", errors.Errorf("malformed %q response: %#v", cmd, m)
 	}
 	return net.JoinHostPort(m["ip"], m["port"]), nil
 }

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	. "testing"
 
+	errors "golang.org/x/xerrors"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +70,7 @@ func (s *sentinelStub) newConn(network, addr string) (Conn, error) {
 		}
 	}
 	if !found {
-		return nil, fmt.Errorf("%q not in sentinel cluster", addr)
+		return nil, errors.Errorf("%q not in sentinel cluster", addr)
 	}
 
 	conn, stubCh := PubSubStub(network, addr, func(args []string) interface{} {
@@ -76,7 +78,7 @@ func (s *sentinelStub) newConn(network, addr string) (Conn, error) {
 		defer s.Unlock()
 
 		if args[0] != "SENTINEL" {
-			return fmt.Errorf("command %q not supported by stub", args[0])
+			return errors.Errorf("command %q not supported by stub", args[0])
 		}
 
 		switch args[1] {
@@ -100,7 +102,7 @@ func (s *sentinelStub) newConn(network, addr string) (Conn, error) {
 			}
 			return ret
 		default:
-			return fmt.Errorf("subcommand %q not supported by stub", args[1])
+			return errors.Errorf("subcommand %q not supported by stub", args[1])
 		}
 	})
 	s.stubChs[stubCh] = true

--- a/stream.go
+++ b/stream.go
@@ -3,12 +3,13 @@ package radix
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"math"
 	"strconv"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/internal/bytesutil"
 	"github.com/mediocregopher/radix/v3/resp"

--- a/stub.go
+++ b/stub.go
@@ -3,10 +3,11 @@ package radix
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"net"
 	"sync"
 	"time"
+
+	errors "golang.org/x/xerrors"
 
 	"github.com/mediocregopher/radix/v3/resp"
 	"github.com/mediocregopher/radix/v3/resp/resp2"

--- a/stub_test.go
+++ b/stub_test.go
@@ -8,6 +8,8 @@ import (
 	. "testing"
 	"time"
 
+	errors "golang.org/x/xerrors"
+
 	"github.com/mediocregopher/radix/v3/resp/resp2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +29,7 @@ func testStub() Conn {
 		case "ECHO":
 			return args[1]
 		default:
-			return fmt.Errorf("testStub doesn't support command %q", args[0])
+			return errors.Errorf("testStub doesn't support command %q", args[0])
 		}
 	})
 }
@@ -113,7 +115,7 @@ func ExampleStub() {
 			m[args[1]] = args[2]
 			return nil
 		default:
-			return fmt.Errorf("this stub doesn't support command %q", args[0])
+			return errors.Errorf("this stub doesn't support command %q", args[0])
 		}
 	})
 


### PR DESCRIPTION
go 1.13 will introduce new functions and fuctionality to the errors
package, but older versions of go will not receive these upgrades. To
compensate there has been released an xerrors package, which seemlessly
implements these upgrades. We will keep using xerrors so that older go
versions can make use of these changes. We will do so until go 1.14 is
released, at which point all supported go versions will have the new
error functionality.

(updates #109)