### PR TITLE
have resp2 fully discard the RESP message on the wire, in the case of an unmarshaling error, whenever possible

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -45,6 +45,8 @@ func (ioc *ioErrConn) Decode(m resp.Unmarshaler) error {
 	err := ioc.Conn.Decode(m)
 	if nerr, _ := err.(net.Error); nerr != nil {
 		ioc.lastIOErr = err
+	} else if !errors.As(err, new(resp.ErrDiscarded)) {
+		ioc.lastIOErr = err
 	}
 	return err
 }

--- a/pubsub.go
+++ b/pubsub.go
@@ -68,7 +68,7 @@ func (m *PubSubMessage) UnmarshalRESP(br *bufio.Reader) error {
 		if err := (resp2.Any{}).UnmarshalRESP(br); err != nil {
 			return err
 		}
-		return errNotPubSubMessage
+		return resp.ErrDiscarded{Err: errNotPubSubMessage}
 	}
 
 	var ah resp2.ArrayHeader
@@ -310,7 +310,7 @@ func (c *pubSubConn) spin() {
 		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 			c.testEvent("timeout")
 			continue
-		} else if err == errNotPubSubMessage {
+		} else if errors.Is(err, errNotPubSubMessage) {
 			c.cmdResCh <- nil
 			continue
 		} else if err != nil {

--- a/resp/resp.go
+++ b/resp/resp.go
@@ -15,9 +15,28 @@ type Marshaler interface {
 }
 
 // Unmarshaler is the interface implemented by types that can unmarshal a RESP
-// description of themselves.
+// description of themselves. UnmarshalRESP should _always_ fully consume a RESP
+// message off the reader, unless there is an error returned from the reader
+// itself.
 //
 // Note that, unlike Marshaler, Unmarshaler _must_ take in a *bufio.Reader.
 type Unmarshaler interface {
 	UnmarshalRESP(*bufio.Reader) error
+}
+
+// ErrDiscarded is used to wrap an error encountered while unmarshaling a
+// message. If an error was encountered during unmarshaling but the rest of the
+// message was successfully discarded off of the wire, then the error can be
+// wrapped in this type.
+type ErrDiscarded struct {
+	Err error
+}
+
+func (ed ErrDiscarded) Error() string {
+	return ed.Err.Error()
+}
+
+// Unwrap implements the errors.Wrapper interface.
+func (ed ErrDiscarded) Unwrap() error {
+	return ed.Err
 }

--- a/resp/resp_test.go
+++ b/resp/resp_test.go
@@ -1,0 +1,15 @@
+package resp
+
+import (
+	. "testing"
+
+	"github.com/stretchr/testify/assert"
+	errors "golang.org/x/xerrors"
+)
+
+func TestErrDiscarded(t *T) {
+	err := errors.New("foo")
+	assert.False(t, errors.As(err, new(ErrDiscarded)))
+	assert.True(t, errors.As(ErrDiscarded{Err: err}, new(ErrDiscarded)))
+	assert.True(t, errors.Is(ErrDiscarded{Err: err}, err))
+}


### PR DESCRIPTION
Updates #126 

This makes 2 somewhat significant changes:

- For all unmarshaling methods in `resp2`, try as hard as possible to discard the RESP message on the wire when an unmarshaling error is encountered. For example, if trying to unmarshal a string into an integer, the choices are either don't discard that string and kill the connection, or discard it and resuse the connection. I introduced `resp.ErrDiscarded` to act as a marker for when the RESP element which caused the error has been successfully discarded. Using this, even the Any array unmarshaler is able to use this logic successfully.

- Change how pool decides a connection is unusable. If the error it sees is not explicitly marked with `resp.ErrDiscarded`, then it will kill the connection. This should help mitigate connections getting out of sync between what they think they're reading and what they are reading.