### PR TITLE
Move the traceRedirected call in Cluster to be just before the redire…

### DIFF
--- a/trace/cluster.go
+++ b/trace/cluster.go
@@ -42,4 +42,8 @@ type ClusterRedirected struct {
 	Key           string
 	Moved, Ask    bool
 	RedirectCount int
+
+	// If true, then the MOVED/ASK error which was received will not be honored,
+	// and the call to Do will be returning the MOVED/ASK error.
+	Final bool
 }


### PR DESCRIPTION
…ct actually happening.

Previously there were a few cases where traceRedirected would be called but the redirect wouldn't actually occur. This fixes that.