### PR TITLE
Prevent double send on response channel in pipeliner

### DIFF
--- a/pipeliner.go
+++ b/pipeliner.go
@@ -181,7 +181,10 @@ func (p *pipeliner) flush(reqs []CmdAction) []CmdAction {
 
 		if err := p.c.Do(pipe); err != nil {
 			for _, req := range reqs {
-				req.(*pipelinerCmd).resCh <- err
+				select {
+				case req.(*pipelinerCmd).resCh <- err:
+				default:
+				}
 			}
 		}
 	}()

--- a/pipeliner.go
+++ b/pipeliner.go
@@ -227,10 +227,11 @@ func (p pipelinerPipeline) Run(c Conn) error {
 	}
 	errConn := ioErrConn{Conn: c}
 	for _, req := range p.pipeline {
-		req.(*pipelinerCmd).resCh <- errConn.Decode(req)
+		err := errConn.Decode(req)
 		if errConn.lastIOErr != nil {
 			return errConn.lastIOErr
 		}
+		req.(*pipelinerCmd).resCh <- err
 	}
 	return nil
 }

--- a/pipeliner.go
+++ b/pipeliner.go
@@ -181,10 +181,7 @@ func (p *pipeliner) flush(reqs []CmdAction) []CmdAction {
 
 		if err := p.c.Do(pipe); err != nil {
 			for _, req := range reqs {
-				select {
-				case req.(*pipelinerCmd).resCh <- err:
-				default:
-				}
+				req.(*pipelinerCmd).resCh <- err
 			}
 		}
 	}()


### PR DESCRIPTION
When a non recoverable error occured on in implicit pipeline the `*pipelinerCmd` that triggered the error would receive it twice, once from `Run` and once from the `flush` goroutine, which would lead to problems when the `*pipelinerCmd` was reused later for another command. 

Updates #126
Fixes #144