### PR TITLE
action: Return a more detailed error on decode error

### DIFF
--- a/action.go
+++ b/action.go
@@ -443,10 +443,25 @@ func (p pipeline) Run(c Conn) error {
 	}
 	for _, cmd := range p {
 		if err := c.Decode(cmd); err != nil {
-			return err
+			return decodeErr(cmd, err)
 		}
 	}
 	return nil
+}
+
+func decodeErr(cmd CmdAction, err error) error {
+	c, ok := cmd.(*cmdAction)
+	if ok {
+		return fmt.Errorf(
+			"failed to decode pipeline CmdAction '%v' with keys %v: %v",
+			c.cmd,
+			c.Keys(),
+			err)
+	}
+	return fmt.Errorf(
+		"failed to decode pipeline CmdAction '%v': %v",
+		cmd,
+		err)
 }
 
 // MarshalRESP implements the resp.Marshaler interface, so that the pipeline can


### PR DESCRIPTION
As part of the pipeline execution, all CmdActions are being decoded with
the response returned from redis.
If an error occurs, it immediately returns the error.
Since pipeline executes many CmdActions, the error returned might not reflect which CmdAction failed, that might cause a lot of debug time to find out which command has failed.
the following PR suggests to add more information about the origin command that failed, if an error occurs on decode.

Here is an example of the existing error we get when failing to run a set of commands
that only one of them is problematic:

```
p.client.Do(radix.Pipeline([]radix.CmdAction{
... // Other commands
// Here I switched the places of expire and addedVal which caused the failure
radix.FlatCmd(nil,"setex", key, addedVal, expire),
... // Other commands
)}
```

The error which we get in this case is: 
> "error":"ERR value is not an integer or out of range"

As you can see, there is not much information to figure out which command exactly failed so I will have to look on the entire CmdActions in the pipeline to figure out which one is the problematic command.

Using the following PR, the error should be much more informative:
> "error": "failed to decode pipeline CmdAction 'setex' with keys [key]: ERR value is not an integer or out of range"}

@chipchaderez