### PR TITLE
add an Action field to trace.PoolDoCompleted

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -602,7 +602,7 @@ func (p *Pool) Do(a Action) error {
 	startTime := time.Now()
 	if p.pipeliner != nil && p.pipeliner.CanDo(a) {
 		err := p.pipeliner.Do(a)
-		p.traceDoCompleted(time.Since(startTime), err)
+		p.traceDoCompleted(a, time.Since(startTime), err)
 
 		return err
 	}
@@ -614,15 +614,16 @@ func (p *Pool) Do(a Action) error {
 
 	err = c.Do(a)
 	p.put(c)
-	p.traceDoCompleted(time.Since(startTime), err)
+	p.traceDoCompleted(a, time.Since(startTime), err)
 
 	return err
 }
 
-func (p *Pool) traceDoCompleted(elapsedTime time.Duration, err error) {
+func (p *Pool) traceDoCompleted(action Action, elapsedTime time.Duration, err error) {
 	if p.opts.pt.DoCompleted != nil {
 		p.opts.pt.DoCompleted(trace.PoolDoCompleted{
 			PoolCommon:  p.traceCommon(),
+			Action:      action,
 			AvailCount:  len(p.pool),
 			ElapsedTime: elapsedTime,
 			Err:         err,

--- a/trace/pool.go
+++ b/trace/pool.go
@@ -108,14 +108,19 @@ type PoolConnClosed struct {
 type PoolDoCompleted struct {
 	PoolCommon
 
+	// Action is the Action which was passed into the Do method. The type of
+	// this field is `interface{}` in order to prevent an import loop between
+	// the radix and trace packages.
+	Action interface{}
+
 	// AvailCount indicates the total number of connections the Pool is holding
 	// on to which are available for usage at the moment the trace occurs.
 	AvailCount int
 
-	// How long it took to send command.
+	// How long it took to perform the Action.
 	ElapsedTime time.Duration
 
-	// This is the error returned from redis.
+	// This is the error returned from the Action, if any.
 	Err error
 }
 


### PR DESCRIPTION
Fixes #159 

@fastest963 here's this. The `Action` field has to be an `inteferface{}` since the `trace` package can't import the main `radix` package (due to import loops). Since there's not much someone could do with the `Action` without doing a type-cast on it anyway I don't think this matters much.