### PR TITLE
Update Travis for Go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: go
 go:
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
 
 services:
   - redis-server
@@ -10,7 +10,7 @@ services:
 before_install:
   # update to latest version of redis
   - sudo apt-get install -y redis-server
-  - GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+  - GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
 
 script:
   # for some reason go test -v -race ./... doesn't work on travis, so use this


### PR DESCRIPTION
Also update golangci-lint for Go 1.13 support.