### PR TITLE
Fix alignment for atomic values in structs

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -110,12 +110,15 @@ func ClusterWithTrace(ct trace.ClusterTrace) ClusterOpt {
 // with it, including a set of pools to each of its instances. All methods on
 // Cluster are thread-safe
 type Cluster struct {
+	// Atomic fields must be at the beginning of the struct since they must be
+	// correctly aligned or else access may cause panics on 32-bit architectures
+	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	lastClusterdown int64 // unix timestamp in milliseconds, atomic
+
 	co clusterOpts
 
 	// used to deduplicate calls to sync
 	syncDedupe *dedupe
-
-	lastClusterdown int64 // unix timestamp in milliseconds, atomic
 
 	l              sync.RWMutex
 	pools          map[string]Client

--- a/pool.go
+++ b/pool.go
@@ -236,6 +236,11 @@ func PoolWithTrace(pt trace.PoolTrace) PoolOpt {
 // performance during low-concurrency usage. It can be disabled using
 // PoolPipelineWindow(0, 0).
 type Pool struct {
+	// Atomic fields must be at the beginning of the struct since they must be
+	// correctly aligned or else access may cause panics on 32-bit architectures
+	// See https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	totalConns int64 // atomic, must only be access using functions from sync/atomic
+
 	opts          poolOpts
 	network, addr string
 	size          int
@@ -245,10 +250,6 @@ type Pool struct {
 	// when closed is true (closed is also protected by l)
 	pool   chan *ioErrConn
 	closed bool
-
-	// totalConns is an atomic value and should only be accessed by the atomic
-	// package.
-	totalConns int64
 
 	pipeliner *pipeliner
 


### PR DESCRIPTION
Checked via github.com/dominikh/go-tools/cmd/structlayout

Fixes #169 