### PR TITLE
Fix traced close reason when pool is full

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -557,7 +557,7 @@ func (p *Pool) put(ioc *ioErrConn) bool {
 	// the pool might close here, but that's fine, because all that's happening
 	// at this point is that the connection is being closed
 	ioc.Close()
-	p.traceConnClosed(trace.PoolConnClosedReasonPoolClosed)
+	p.traceConnClosed(trace.PoolConnClosedReasonPoolFull)
 	atomic.AddInt64(&p.totalConns, -1)
 	return false
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -134,7 +134,13 @@ func TestPoolGet(t *T) {
 
 func TestPoolOnFull(t *T) {
 	t.Run("onFullClose", func(t *T) {
-		pool := testPool(1, PoolOnFullClose())
+		var reason trace.PoolConnClosedReason
+		pool := testPool(1,
+			PoolOnFullClose(),
+			PoolWithTrace(trace.PoolTrace{ConnClosed: func(c trace.PoolConnClosed) {
+				reason = c.Reason
+			}}),
+		)
 		defer pool.Close()
 		assert.Equal(t, 1, len(pool.pool))
 
@@ -142,6 +148,7 @@ func TestPoolOnFull(t *T) {
 		assert.NoError(t, err)
 		pool.put(spc)
 		assert.Equal(t, 1, len(pool.pool))
+		assert.Equal(t, trace.PoolConnClosedReasonPoolFull, reason)
 	})
 
 	t.Run("onFullBuffer", func(t *T) {

--- a/trace/pool.go
+++ b/trace/pool.go
@@ -86,7 +86,7 @@ const (
 	PoolConnClosedReasonBufferDrain PoolConnClosedReason = "buffer drained"
 
 	// PoolConnClosedReasonPoolFull indicates a connection was closed due to
-	// the Pool already being full. See The radix.PoolOnFull options.
+	// the Pool already being full. See The radix.PoolOnFullClose options.
 	PoolConnClosedReasonPoolFull PoolConnClosedReason = "pool full"
 )
 


### PR DESCRIPTION
Also extend the `TestPoolOnFull`/`onFullClose` test to check the reason and fix the function reference in the documentation for `PoolConnClosedReasonPoolFull`. 