### PR TITLE
Simplify and improve pipeliner error handling

### DIFF
--- a/pipeliner.go
+++ b/pipeliner.go
@@ -1,6 +1,7 @@
 package radix
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -221,7 +222,12 @@ type pipelinerPipeline struct {
 	pipeline
 }
 
-func (p pipelinerPipeline) Run(c Conn) error {
+func (p pipelinerPipeline) Run(c Conn) (err error) {
+	defer func() {
+		if v := recover(); v != nil {
+			err = fmt.Errorf("%s", v)
+		}
+	}()
 	if err := c.Encode(p); err != nil {
 		return err
 	}


### PR DESCRIPTION
As reported in #189, the current `pipeliner` implementation does not handle panics when marshalling/unmarshalling and will kill the whole program. Fix this by recovering any panics from within the `pipelinerPipeline.Run` method.

Since I am here already I also refactored the error handling for the pipeliner which was more complex and subtle than it should have been.

Updates #189