### PR TITLE
Avoid allocating a []byte when reading stream names

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -355,7 +355,7 @@ func (sr *streamReader) Next() (stream string, entries []StreamEntry, ok bool) {
 			continue
 		}
 
-		stream = string(sre.stream)
+		stream = sre.stream
 
 		// do not update the ID for XREADGROUP when we are not reading unacknowledged entries.
 		if sr.cmd == "XREAD" || (sr.cmd == "XREADGROUP" && sr.ids[stream] != ">") {
@@ -369,7 +369,7 @@ func (sr *streamReader) Next() (stream string, entries []StreamEntry, ok bool) {
 }
 
 type streamReaderEntry struct {
-	stream  []byte
+	stream  string
 	entries []StreamEntry
 }
 
@@ -382,12 +382,11 @@ func (s *streamReaderEntry) UnmarshalRESP(br *bufio.Reader) error {
 		return errors.New("invalid xread[group] response")
 	}
 
-	var stream resp2.BulkStringBytes
-	stream.B = s.stream[:0]
+	var stream resp2.BulkString
 	if err := stream.UnmarshalRESP(br); err != nil {
 		return err
 	}
-	s.stream = stream.B
+	s.stream = stream.S
 
 	return (resp2.Any{I: &s.entries}).UnmarshalRESP(br)
 }


### PR DESCRIPTION
Removes one allocation when calling StreamReader.Next:

```
name            old alloc/op   new alloc/op   delta
StreamReader-8    14.6kB ± 0%    14.5kB ± 0%  -0.22%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
StreamReader-8       146 ± 0%       145 ± 0%  -0.68%  (p=0.008 n=5+5)
```