### PR TITLE
Add support for secondary reads with cluster

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -250,7 +250,10 @@ func TestClusterDoSecondary(t *T) {
 	assert.Equal(t, value, res2)
 	assert.Equal(t, 1, redirects)
 
-	secAddr := c.secondaries[c.addrForKey(key)][0].Addr
+	var secAddr string
+	for secAddr = range c.secondaries[c.addrForKey(key)] {
+		break
+	}
 	sec, err := c.Client(secAddr)
 	require.NoError(t, err)
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -273,3 +273,11 @@ func TestClusterDoSecondary(t *T) {
 	assert.Equal(t, value, res4)
 	assert.Equal(t, 2, redirects)
 }
+
+var clusterAddrs []string
+
+func ExampleClusterPoolFunc_defaultClusterConnFunc() {
+	NewCluster(clusterAddrs, ClusterPoolFunc(func(network, addr string) (Client, error) {
+		return NewPool(network, addr, 4, PoolConnFunc(DefaultClusterConnFunc))
+	}))
+}

--- a/cluster_topo.go
+++ b/cluster_topo.go
@@ -138,16 +138,6 @@ func (tt ClusterTopo) Primaries() ClusterTopo {
 	return mtt
 }
 
-func (tt ClusterTopo) secondariesByPrimary() map[string][]ClusterNode {
-	m := make(map[string][]ClusterNode, len(tt)/2)
-	for _, node := range tt {
-		if node.SecondaryOfAddr != "" {
-			m[node.SecondaryOfAddr] = append(m[node.SecondaryOfAddr], node)
-		}
-	}
-	return m
-}
-
 // we only use this type during unmarshalling, the topo Unmarshal method will
 // convert these into ClusterNodes
 type topoSlotSet struct {

--- a/cluster_topo.go
+++ b/cluster_topo.go
@@ -138,6 +138,16 @@ func (tt ClusterTopo) Primaries() ClusterTopo {
 	return mtt
 }
 
+func (tt ClusterTopo) secondariesByPrimary() map[string][]ClusterNode {
+	m := make(map[string][]ClusterNode, len(tt)/2)
+	for _, node := range tt {
+		if node.SecondaryOfAddr != "" {
+			m[node.SecondaryOfAddr] = append(m[node.SecondaryOfAddr], node)
+		}
+	}
+	return m
+}
+
 // we only use this type during unmarshalling, the topo Unmarshal method will
 // convert these into ClusterNodes
 type topoSlotSet struct {


### PR DESCRIPTION
Second part of #174

This currently requires users to manually send the `READONLY` command using a custom `ClusterPoolFunc` since we can not automatically send `READONLY` to all connections.

Updates #174