### PR TITLE
Update Travis for Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: go
 go:
-  - "1.12.x"
   - "1.13.x"
+  - "1.14.x"
 
 services:
   - redis-server
@@ -10,7 +10,7 @@ services:
 before_install:
   # update to latest version of redis
   - sudo apt-get install -y redis-server
-  - GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
+  - GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 
 script:
   # for some reason go test -v -race ./... doesn't work on travis, so use this


### PR DESCRIPTION
Go 1.14.0 was released on Feb 25th and the [1.14.1 release is already in the oven](https://github.com/golang/go/issues/37934).

Also update golangci-lint to version 1.24.0.