### PR TITLE
Fix for issue #208 - All cluster down and start recovering and yet "no pools available" error comes

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -319,6 +319,9 @@ func (c *Cluster) Topo() ClusterTopo {
 func (c *Cluster) getTopo(p Client) (ClusterTopo, error) {
 	var tt ClusterTopo
 	err := p.Do(Cmd(&tt, "CLUSTER", "SLOTS"))
+	if tt == nil && err == nil {
+		err = errors.New("No Topology Available")
+	}
 	return tt, err
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -320,6 +320,8 @@ func (c *Cluster) getTopo(p Client) (ClusterTopo, error) {
 	var tt ClusterTopo
 	err := p.Do(Cmd(&tt, "CLUSTER", "SLOTS"))
 	if tt == nil && err == nil {
+		//This will happen between when nodes starts coming up after cluster goes down and
+		//Cluster swarm yet not ready using those nodes.
 		err = errors.New("No Topology Available")
 	}
 	return tt, err

--- a/cluster.go
+++ b/cluster.go
@@ -319,10 +319,10 @@ func (c *Cluster) Topo() ClusterTopo {
 func (c *Cluster) getTopo(p Client) (ClusterTopo, error) {
 	var tt ClusterTopo
 	err := p.Do(Cmd(&tt, "CLUSTER", "SLOTS"))
-	if tt == nil && err == nil {
+	if len(tt) == 0 && err == nil {
 		//This will happen between when nodes starts coming up after cluster goes down and
 		//Cluster swarm yet not ready using those nodes.
-		err = errors.New("No Topology Available")
+		err = errors.New("no cluster slots assigned")
 	}
 	return tt, err
 }


### PR DESCRIPTION
### This pull request is related to issue #208 

## Detailed Debug Observation:
while debugging I found that the Sync depends on pools array to be filled in.
#### (c *Cluster) Sync() Call No. 1:
when it goes to get topology from cluster swarm from function "(c *Cluster) getTopo" it returns
```
tt == []
err == nil
```

This happens between "nodes came up" and "cluster yet not created" ( means master/slave arrangement yet not created on redis server).

At that time topology didn't exist and though it goes to below piece of code:
c.pools is having all the previous connection but got deleted as tm is empty.

```
		tm := tt.Map()
		for addr, p := range c.pools {
			if _, ok := tm[addr]; !ok {
				toclose = append(toclose, p)
				delete(c.pools, addr)
			}
		}
```

#### (c *Cluster) Sync() Call No. 2:
Now next "(c *Cluster) Do" comes and it goes to "c.doInner". Over there while calling c.pool error starts coming as "no pools available".

Ideally everything is correct till now. It should correct/update (update with new topology and start executing new commands) itself just after next successful Sync call after cluster recovered. But pool never get filled with new topology after many Sync calls. This happens due to 'c.pool(**""**)' is being called from "(c *Cluster) Sync()". which leads to check of nil ("") address and no pool in c.pools and giving FALSE POSITIVE result as.

```
tt == []
err == nil
```

This issue do not come when the node up and cluster creation happens very quickly, giving no time to call Sync between this process.

## Suggested Solution:
As giving ``` tt == [] ``` and ``` err == nil ``` while cluster is yet not ready although nodes are ready is a False Positive output. we need to set error so that it do not clear ```c.pools``` and wait till next Sync to give True Positive result. True positive result will be available as soon as cluster swarm has been created with topology.