### PR TITLE
Add Empty property to MaybeNil.

### DIFF
--- a/resp/resp2/resp.go
+++ b/resp/resp2/resp.go
@@ -64,6 +64,7 @@ func (p prefix) String() string {
 var (
 	nilBulkString = []byte("$-1\r\n")
 	nilArray      = []byte("*-1\r\n")
+	emptyArray    = []byte("*0\r\n")
 )
 
 var bools = [][]byte{
@@ -1291,4 +1292,9 @@ func (rm RawMessage) UnmarshalInto(u resp.Unmarshaler) error {
 // IsNil returns true if the contents of RawMessage are one of the nil values.
 func (rm RawMessage) IsNil() bool {
 	return bytes.Equal(rm, nilBulkString) || bytes.Equal(rm, nilArray)
+}
+
+// IsEmptyArray returns true if the contents of RawMessage is empty array value.
+func (rm RawMessage) IsEmptyArray() bool {
+	return bytes.Equal(rm, emptyArray)
 }

--- a/resp/resp2/resp_test.go
+++ b/resp/resp2/resp_test.go
@@ -616,8 +616,9 @@ func TestAnyUnmarshal(t *T) {
 
 func TestRawMessage(t *T) {
 	rmtests := []struct {
-		b     string
-		isNil bool
+		b       string
+		isNil   bool
+		isEmpty bool
 	}{
 		{b: "+\r\n"},
 		{b: "+foo\r\n"},
@@ -632,6 +633,7 @@ func TestRawMessage(t *T) {
 		{b: "$8\r\nfoo\r\nbar\r\n"},
 		{b: "*2\r\n:1\r\n:2\r\n"},
 		{b: "*-1\r\n", isNil: true},
+		{b: "*0\r\n", isEmpty: true},
 	}
 
 	// one at a time
@@ -642,6 +644,7 @@ func TestRawMessage(t *T) {
 			require.Nil(t, rm.MarshalRESP(buf))
 			assert.Equal(t, rmt.b, buf.String())
 			assert.Equal(t, rmt.isNil, rm.IsNil())
+			assert.Equal(t, rmt.isEmpty, rm.IsEmptyArray())
 		}
 		{
 			var rm RawMessage


### PR DESCRIPTION
This is useful for commands like HGETALL that always returns non-nil array responses.

Closes #206