### PR TITLE
fix unmarshalling StreamEntry with nil array for fields

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -155,16 +155,19 @@ func (s *StreamEntry) UnmarshalRESP(br *bufio.Reader) error {
 	if err := ah.UnmarshalRESP(br); err != nil {
 		return err
 	}
-	if ah.N%2 != 0 {
+
+	for k := range s.Fields {
+		delete(s.Fields, k)
+	}
+
+	if ah.N == -1 {
+		return nil
+	} else if ah.N%2 != 0 {
 		return errInvalidStreamEntry
 	}
 
 	if s.Fields == nil {
 		s.Fields = make(map[string]string, ah.N/2)
-	} else {
-		for k := range s.Fields {
-			delete(s.Fields, k)
-		}
 	}
 
 	var bs resp2.BulkString


### PR DESCRIPTION
Redis allows access to pending unacknowledged messages with `XREADGROUP GROUP mygroup myconsumer STREAMS mystream 0`. If those stream entries have been trimmed or deleted, the answer will look like this:
```
1) 1) "mystream"
   2) 1) 1) "1593607546396-0"
         2) (nil)
```
`radix.StreamReader` fails to return these stream entries and returns "invalid stream entry" error instead.