### PR TITLE
Correctly handle wrapped errors for clusters.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -666,10 +666,12 @@ func (c *Cluster) doInner(a Action, addr, key string, ask bool, attempts int) er
 		return nil
 	}
 
-	if !errors.As(err, new(resp2.Error)) {
+	var respErr resp2.Error
+	if !errors.As(err, &respErr) {
 		return err
 	}
-	msg := err.Error()
+
+	msg := respErr.Error()
 
 	clusterDown := strings.HasPrefix(msg, "CLUSTERDOWN ")
 	clusterDownChanged := c.setClusterDown(clusterDown)


### PR DESCRIPTION
If a custom `radix.Conn` that returns wrapped errors is used in conjunction with the cluster client, then it will fail to follow MOVED/ASK redirects. This is due to `errors.As` being used incorrectly.