### PR TITLE
Fixed deadlock in PersistentPubSub.cmd call after close was called

### DIFF
--- a/pubsub_persistent_test.go
+++ b/pubsub_persistent_test.go
@@ -106,3 +106,27 @@ func TestPersistentPubSubClose(t *T) {
 		close(msgCh)
 	}
 }
+
+func TestPersistentPubSubUseAfterCloseDeadlock(t *T) {
+	channel := "TestPersistentPubSubUseAfterCloseDeadlock:" + randStr()
+
+	p := PersistentPubSub("", "", func(_, _ string) (Conn, error) {
+		return dial(), nil
+	})
+	msgCh := make(chan PubSubMessage)
+	p.Subscribe(msgCh, channel)
+	p.Close()
+
+	errch := make(chan error)
+	go func() {
+		errch <- p.PUnsubscribe(msgCh, channel)
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		assert.Fail(t, "PUnsubscribe call timeout")
+	case err := <-errch:
+		assert.Equal(t, err, ErrPersistentPubSubClosed)
+	}
+
+}

--- a/pubsub_persistent_test.go
+++ b/pubsub_persistent_test.go
@@ -126,7 +126,7 @@ func TestPersistentPubSubUseAfterCloseDeadlock(t *T) {
 	case <-time.After(time.Second):
 		assert.Fail(t, "PUnsubscribe call timeout")
 	case err := <-errch:
-		assert.Equal(t, err, ErrPersistentPubSubClosed)
+		assert.Error(t, err)
 	}
 
 }


### PR DESCRIPTION
Hi @mediocregopher 

It would be great if any persistentPubSub.cmd (Subscribe/Unsubscribe/etc.) calls will returns error
after pubsub was closed instead of forever lock

Thanks!