### PR TITLE
Remove an allocation in pipeline processing

### DIFF
--- a/action.go
+++ b/action.go
@@ -584,15 +584,15 @@ func (p *pipeline) Perform(ctx context.Context, c Conn) error {
 	// first error encountered, but it does take into account all the others
 	// when determining if that error should be wrapped in ErrConnUsable.
 	var err error
-	var errConnUsable resp.ErrConnUsable
 	connUsable := true
 	for _, m := range p.mm {
 		if m.err != nil {
 			if err == nil {
 				err = fmt.Errorf("command %+v in pipeline returned error: %w", m.marshal, m.err)
 			}
-			if !errors.As(m.err, &errConnUsable) {
+			if !errors.As(m.err, new(resp.ErrConnUsable)) {
 				connUsable = false
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Declaring the error outside the loop and passing a pointer to `errors.As` causes an unnecessary allocation since the compiler can't currently detect that the value does not escape.

By instead passing a new error value on each iteration we allow the compiler to correctly identify the value as non-escaping and allocate it on the stack.

```bash
$ benchstat before.txt after.txt | grep -v '/no_pipeline/'
name                                             old time/op    new time/op    delta
Drivers/serial/pipeline/small_kv/radixv4-8         28.1µs ± 3%    28.5µs ± 4%     ~     (p=0.156 n=10+9)
Drivers/serial/pipeline/large_kv/radixv4-8         53.9µs ± 1%    54.2µs ± 2%   +0.72%  (p=0.022 n=9+10)
Drivers/parallel/pipeline/small_kv/radixv4-8       4.44µs ± 1%    4.42µs ± 0%   -0.50%  (p=0.002 n=10+10)
Drivers/parallel/pipeline/large_kv/radixv4-8       16.2µs ± 0%    16.2µs ± 1%     ~     (p=0.363 n=10+10)

name                                             old alloc/op   new alloc/op   delta
Drivers/serial/pipeline/small_kv/radixv4-8          83.0B ± 0%     67.0B ± 0%  -19.28%  (p=0.000 n=10+10)
Drivers/serial/pipeline/large_kv/radixv4-8         12.5kB ± 0%    12.5kB ± 0%   -0.13%  (p=0.000 n=10+10)
Drivers/parallel/pipeline/small_kv/radixv4-8         422B ± 0%      405B ± 0%   -3.96%  (p=0.000 n=10+9)
Drivers/parallel/pipeline/large_kv/radixv4-8       12.9kB ± 0%    12.9kB ± 0%   -0.12%  (p=0.000 n=10+10)

name                                             old allocs/op  new allocs/op  delta
Drivers/serial/pipeline/small_kv/radixv4-8           5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
Drivers/serial/pipeline/large_kv/radixv4-8           5.00 ± 0%      4.00 ± 0%  -20.00%  (p=0.000 n=10+10)
Drivers/parallel/pipeline/small_kv/radixv4-8         12.0 ± 0%      11.0 ± 0%   -8.33%  (p=0.000 n=10+10)
Drivers/parallel/pipeline/large_kv/radixv4-8         12.0 ± 0%      11.0 ± 0%   -8.33%  (p=0.000 n=10+10)
```