### PR TITLE
Reduce allocations for pipelines using pre-allocated slice backing memory

### DIFF
--- a/action.go
+++ b/action.go
@@ -479,9 +479,9 @@ type pipelineMarshalerUnmarshaler struct {
 // rather not expose to users.
 type pipeline struct {
 	// preallocated buffers of slices to avoid allocating for small pipelines
-	actionsBuf        [4]Action
-	mmBuf             [4]pipelineMarshalerUnmarshaler
-	propertiesKeysBuf [4]string
+	actionsBuf        [8]Action
+	mmBuf             [8]pipelineMarshalerUnmarshaler
+	propertiesKeysBuf [8]string
 
 	actions    []Action
 	mm         []pipelineMarshalerUnmarshaler


### PR DESCRIPTION
For each `Action` added to a `Pipeline` the `Pipeline` needs to append values to at least 2 slices (`actions`, `mm` and in most cases the `Keys` slice of the `ActionProperties`) which causes a lot of allocations.

While these allocations can be avoided by reusing `Pipeline`s, newly allocated `Pipeline`s still always incur some allocations.

For a `Pipeline` with only 1 `Action` that uses 1 key a new `Pipeline` currently needs 3 extra allocations. For a `Pipeline` with 2 `Action`s each using 1 key a `new Pipeline` currently needs 6 extra allocations. Similarly a new `Pipeline` with 4 `Action`s each using 1 key currently needs 9 extra allocations.

The number of extra allocations for a `Pipeline` with N `Action`s (assuming each `Action` is for 1 key) can be calculated automatically like this: https://play.golang.org/p/fjOdoHoHpzE (Note: These numbers can change with new Go releases)

With this change new `Pipeline`s avoid some of the allocations by pre-allocating small 4-element arrays as part of the `Pipeline`s initial allocation, that are then used as initial backing memory for each of the 3 slices.

The number 4 was chosen to avoid bloating memory use too much for applications that are mainly using small `Pipeline`s (N <= 2) while still allowing up to 9 allocations to be avoided (N = 4).

```bash
$ benchstat before.txt after.txt | grep -v '/no_pipeline/'
name                                             old time/op    new time/op    delta
Drivers/serial/pipeline/small_kv/radixv4-8         28.1µs ± 3%    29.0µs ± 5%   +2.91%  (p=0.023 n=10+10)
Drivers/serial/pipeline/large_kv/radixv4-8         53.9µs ± 1%    53.7µs ± 1%     ~     (p=0.356 n=9+10)
Drivers/parallel/pipeline/small_kv/radixv4-8       4.44µs ± 1%    4.39µs ± 1%   -1.31%  (p=0.000 n=10+9)
Drivers/parallel/pipeline/large_kv/radixv4-8       16.2µs ± 0%    16.2µs ± 1%     ~     (p=0.211 n=10+9)

name                                             old alloc/op   new alloc/op   delta
Drivers/serial/pipeline/small_kv/radixv4-8          83.0B ± 0%     83.0B ± 0%     ~     (all equal)
Drivers/serial/pipeline/large_kv/radixv4-8         12.5kB ± 0%    12.5kB ± 0%     ~     (p=0.211 n=10+10)
Drivers/parallel/pipeline/small_kv/radixv4-8         422B ± 0%      502B ± 0%  +19.04%  (p=0.000 n=10+10)
Drivers/parallel/pipeline/large_kv/radixv4-8       12.9kB ± 0%    13.0kB ± 0%   +0.62%  (p=0.000 n=10+10)

name                                             old allocs/op  new allocs/op  delta
Drivers/serial/pipeline/small_kv/radixv4-8           5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Drivers/serial/pipeline/large_kv/radixv4-8           5.00 ± 0%      5.00 ± 0%     ~     (all equal)
Drivers/parallel/pipeline/small_kv/radixv4-8         12.0 ± 0%       6.0 ± 0%  -50.00%  (p=0.000 n=10+10)
Drivers/parallel/pipeline/large_kv/radixv4-8         12.0 ± 0%       6.0 ± 0%  -50.00%  (p=0.000 n=10+10)
```