### PR TITLE
Update the auth error message used in tests

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -86,6 +86,7 @@ func TestDialAuth(t *T) {
 			{url: "127.0.0.1:6379", dialOptUser: "mediocregopher", dialOptPass: "myPass"},
 		}, []string{
 			"WRONGPASS invalid username-password pair",
+			"WRONGPASS invalid username-password pair or user is disabled.",
 		})
 	})
 }


### PR DESCRIPTION
The message has changed so the test failed with newer Redis versions.

See here: https://github.com/redis/redis/blob/4a474843fbd018cd323971b57dec976d7ad0278d/src/acl.c#L2249