### PR TITLE
v4: Allow setting the protocol version for new connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 script:
   # for some reason go test -v -race ./... doesn't work on travis, so use this
   - go list ./... | xargs -n1 go test -race
+  - go list ./... | xargs -n1 go test -race -resp3
   - golangci-lint run -D errcheck -E goimports -E golint -E misspell -E stylecheck -E unconvert
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ before_install:
 
 script:
   # for some reason go test -v -race ./... doesn't work on travis, so use this
-  - go list ./... | xargs -n1 go test -race
-  - go list ./... | xargs -n1 go test -race -resp3
+  - go list ./... | xargs -n1 go test -race -v
+  - go list ./... | xargs -n1 go test -race -v -resp3
   - golangci-lint run -D errcheck -E goimports -E golint -E misspell -E stylecheck -E unconvert
 
 after_failure:

--- a/conn.go
+++ b/conn.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -192,9 +191,9 @@ type Dialer struct {
 
 	// Protocol can be used to automatically set the RESP protocol version.
 	//
-	// If Protocol is not 0 the Dialer will send a HELLO command with the
+	// If Protocol is not empty the Dialer will send a HELLO command with the
 	// value of Protocol as version, otherwise no HELLO command will be send.
-	Protocol int
+	Protocol string
 
 	// NetDialer is used to create the underlying network connection.
 	//
@@ -341,8 +340,8 @@ func (d Dialer) Dial(ctx context.Context, network, addr string) (Conn, error) {
 		conn.writer(ctx, d.WriteFlushInterval)
 	})
 
-	if d.Protocol != 0 {
-		args := []string{strconv.Itoa(d.Protocol)}
+	if d.Protocol != "" {
+		args := []string{d.Protocol}
 		if d.AuthUser != "" {
 			args = append(args, "AUTH", d.AuthUser, d.AuthPass)
 		} else if d.AuthPass != "" {

--- a/pubsub.go
+++ b/pubsub.go
@@ -63,7 +63,7 @@ func (m *PubSubMessage) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) erro
 	// NOTE: This is technically only true for connections using RESP2, not for
 	// connections using RESP3, but for backwards compatibility with RESP2 we
 	// assume the same limitations for RESP3.
-	if resp3.HasPrefix(br, resp3.SimpleStringPrefix) {
+	if ok, _ := resp3.NextMessageIs(br, resp3.SimpleStringPrefix); ok {
 		// if it's a simple string, discard it (it's probably PONG) and error
 		if err := resp3.Unmarshal(br, nil, o); err != nil {
 			return err
@@ -72,7 +72,7 @@ func (m *PubSubMessage) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) erro
 	}
 
 	var numElems int
-	if resp3.HasPrefix(br, resp3.PushHeaderPrefix) {
+	if ok, _ := resp3.NextMessageIs(br, resp3.PushHeaderPrefix); ok {
 		var ph resp3.PushHeader
 		if err := ph.UnmarshalRESP(br, o); err != nil {
 			return err

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -22,7 +22,7 @@ func assertMsgRead(t *T, msgCh <-chan PubSubMessage) PubSubMessage {
 	select {
 	case m := <-msgCh:
 		return m
-	case <-time.After(5 * time.Second):
+	case <-time.After(15 * time.Second):
 		panic("timedout reading")
 	}
 }

--- a/radix_test.go
+++ b/radix_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"flag"
 	"sync"
 	. "testing"
 	"time"
@@ -17,10 +18,16 @@ func randStr() string {
 	return hex.EncodeToString(b)
 }
 
+var flagRESP3 = flag.Bool("resp3", false, "Enables RESP3 for all tests")
+
 func dial() Conn {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, "tcp", "127.0.0.1:6379")
+	protocol := 0
+	if *flagRESP3 {
+		protocol = 3
+	}
+	c, err := Dialer{Protocol: protocol}.Dial(ctx, "tcp", "127.0.0.1:6379")
 	if err != nil {
 		panic(err)
 	}

--- a/radix_test.go
+++ b/radix_test.go
@@ -23,9 +23,9 @@ var flagRESP3 = flag.Bool("resp3", false, "Enables RESP3 for all tests")
 func dial() Conn {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	protocol := 0
+	protocol := ""
 	if *flagRESP3 {
-		protocol = 3
+		protocol = "3"
 	}
 	c, err := Dialer{Protocol: protocol}.Dial(ctx, "tcp", "127.0.0.1:6379")
 	if err != nil {

--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -160,6 +160,8 @@ func DiscardAttribute(br resp.BufferedReader, o *resp.Opts) error {
 
 // HasPrefix returns true if the next value in the given reader has the given
 // prefix.
+//
+// If there is an error reading from br, HasPrefix will return false.
 func HasPrefix(br resp.BufferedReader, p Prefix) bool {
 	b, err := br.Peek(1)
 	return err == nil && p.doesPrefix(b)

--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -143,7 +143,8 @@ func discardMulti(br resp.BufferedReader, l int, o *resp.Opts) error {
 	return nil
 }
 
-// DiscardAttribute discards a RESP3 attribute if there is one.
+// DiscardAttribute discards the next RESP3 message if it is an attribute message.
+// If the next message is not an attribute message then DiscardAttribute does nothing..
 func DiscardAttribute(br resp.BufferedReader, o *resp.Opts) error {
 	var attrHead AttributeHeader
 	b, err := br.Peek(1)

--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -162,7 +162,7 @@ func DiscardAttribute(br resp.BufferedReader, o *resp.Opts) error {
 // NextMessageIs returns true if the next value in the given reader has the given
 // prefix.
 //
-// If there is an error reading from br, NextMessageIs will return false.
+// If there is an error reading from br, NextMessageIs will return false and the error.
 func NextMessageIs(br resp.BufferedReader, p Prefix) (bool, error) {
 	b, err := br.Peek(1)
 	return err == nil && p.doesPrefix(b), err

--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -159,13 +159,13 @@ func DiscardAttribute(br resp.BufferedReader, o *resp.Opts) error {
 	return discardMulti(br, attrHead.NumPairs*2, o)
 }
 
-// HasPrefix returns true if the next value in the given reader has the given
+// NextMessageIs returns true if the next value in the given reader has the given
 // prefix.
 //
-// If there is an error reading from br, HasPrefix will return false.
-func HasPrefix(br resp.BufferedReader, p Prefix) bool {
+// If there is an error reading from br, NextMessageIs will return false.
+func NextMessageIs(br resp.BufferedReader, p Prefix) (bool, error) {
 	b, err := br.Peek(1)
-	return err == nil && p.doesPrefix(b)
+	return err == nil && p.doesPrefix(b), err
 }
 
 type errUnexpectedPrefix struct {

--- a/stream.go
+++ b/stream.go
@@ -187,7 +187,7 @@ type StreamEntries struct {
 // UnmarshalRESP implements the resp.Unmarshaler interface.
 func (s *StreamEntries) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) error {
 	// For RESP2 we get an array of 2 elements, for RESP 3 we are already inside an map so there is no array header.
-	if resp3.HasPrefix(br, resp3.ArrayHeaderPrefix) {
+	if ok, _ := resp3.NextMessageIs(br, resp3.ArrayHeaderPrefix); ok {
 		var ah resp3.ArrayHeader
 		if err := ah.UnmarshalRESP(br, o); err != nil {
 			return err
@@ -225,7 +225,7 @@ func (s *streamEntriesMap) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) e
 		return err
 	}
 
-	if resp3.HasPrefix(br, resp3.MapHeaderPrefix) {
+	if ok, _ := resp3.NextMessageIs(br, resp3.MapHeaderPrefix); ok {
 		return s.unmarshalRESP3(br, o)
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -3,13 +3,12 @@ package radix
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
 	"strconv"
 	"time"
-
-	"errors"
 
 	"github.com/mediocregopher/radix/v4/internal/bytesutil"
 	"github.com/mediocregopher/radix/v4/resp"
@@ -187,11 +186,14 @@ type StreamEntries struct {
 
 // UnmarshalRESP implements the resp.Unmarshaler interface.
 func (s *StreamEntries) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) error {
-	var ah resp3.ArrayHeader
-	if err := ah.UnmarshalRESP(br, o); err != nil {
-		return err
-	} else if ah.NumElems != 2 {
-		return errors.New("invalid xread[group] response")
+	// For RESP2 we get an array of 2 elements, for RESP 3 we are already inside an map so there is no array header.
+	if resp3.HasPrefix(br, resp3.ArrayHeaderPrefix) {
+		var ah resp3.ArrayHeader
+		if err := ah.UnmarshalRESP(br, o); err != nil {
+			return err
+		} else if ah.NumElems != 2 {
+			return errors.New("invalid xread[group] response")
+		}
 	}
 
 	var stream resp3.BlobString
@@ -200,6 +202,7 @@ func (s *StreamEntries) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) erro
 	}
 	s.Stream = stream.S
 
+	var ah resp3.ArrayHeader
 	if err := ah.UnmarshalRESP(br, o); err != nil {
 		return err
 	}
@@ -210,6 +213,56 @@ func (s *StreamEntries) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) erro
 			return err
 		}
 	}
+	return nil
+}
+
+// streamEntriesMap implements parsing of StreamEntries from XREAD[GROUP] for
+// both RESP2 and RESP3 which use different ways to represent the stream names.
+type streamEntriesMap []StreamEntries
+
+func (s *streamEntriesMap) UnmarshalRESP(br resp.BufferedReader, o *resp.Opts) error {
+	if err := resp3.DiscardAttribute(br, o); err != nil {
+		return err
+	}
+
+	if resp3.HasPrefix(br, resp3.MapHeaderPrefix) {
+		return s.unmarshalRESP3(br, o)
+	}
+
+	return s.unmarshalRESP2(br, o)
+}
+
+func (s *streamEntriesMap) unmarshalRESP2(br resp.BufferedReader, o *resp.Opts) error {
+	return resp3.Unmarshal(br, (*[]StreamEntries)(s), o)
+}
+
+func (s *streamEntriesMap) unmarshalRESP3(br resp.BufferedReader, o *resp.Opts) error {
+	var mh resp3.MapHeader
+	if err := mh.UnmarshalRESP(br, o); err != nil {
+		return err
+	}
+
+	// NOTE: This does not handle streamed map responses, but current Redis
+	// versions don't use streamed maps for XREAD[GROUP] responses so unless
+	// this changes, we panic for now.
+	if mh.StreamedMapHeader {
+		panic("streamed map response from XREAD[GROUP] not supported")
+	}
+
+	ss := *s
+	if cap(ss) >= mh.NumPairs {
+		ss = ss[:mh.NumPairs]
+	} else {
+		ss = make([]StreamEntries, mh.NumPairs)
+	}
+
+	for i := range ss {
+		if err := ss[i].UnmarshalRESP(br, o); err != nil {
+			return err
+		}
+	}
+
+	*s = ss
 	return nil
 }
 
@@ -306,7 +359,7 @@ type streamReader struct {
 	cmd       string   // command. either XREAD or XREADGROUP
 	fixedArgs []string // fixed arguments that always come directly after the command
 
-	unread []StreamEntries
+	unread streamEntriesMap
 	err    error
 }
 


### PR DESCRIPTION
Also fixes the unmarshaling logic for pubsub and stream responses which failed to handle RESP3 response types and adds RESP3 to the tests run by Travis.

Fixes #266