### PR TITLE
Release the RLock in Sentinel's Do before calling client's Do

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -201,8 +201,9 @@ func (sc *Sentinel) dialSentinel() (Conn, error) {
 // Action will likely fail and return an error.
 func (sc *Sentinel) Do(a Action) error {
 	sc.l.RLock()
-	defer sc.l.RUnlock()
-	return sc.clients[sc.primAddr].Do(a)
+	client := sc.clients[sc.primAddr]
+	sc.l.RUnlock()
+	return client.Do(a)
 }
 
 // DoSecondary is like Do but executes the Action on a random replica if possible.


### PR DESCRIPTION
I consistently trigger a peculiar condition, where a non-blocking `radix.CmdAction` command blocks until a different blocking `radix.CmdAction` returns.

The non-blocking command is an `XADD`, and the blocking command is issued by `radix.StreamReader`'s `Next()` method.

I think what happens is:
1. The mutex in `Sentinel` (field `l sync.RWMutex`) is `RLock`ed by the `radix.StreamReader`, and keeps it locked for 5 seconds while executing its `XREAD` command.
2. `ensureSentinelAddrs` tries to `Lock` the `RWMutex` but blocks because the mutex is `RLock`ed by 1.
3. The `XADD` command tries to `RLock` the mutex, but won't, because the go runtime wants to serve the `Lock` caller first, so it doesn't get lock-starved. Therefore `XADD` waits until 1. and 2. finish, before locking the mutex.

With the change in this PR I can't trigger this condition anymore, but if what I think is happening is correct, it can technically still happen, but just is way less likely to.

Here are the goroutine stack dumps for the three goroutines in question during the condition:
```
goroutine 27 [IO wait]:
internal/poll.runtime_pollWait(0x7f3a09ac6b78, 0x72, 0xffffffffffffffff)
	/usr/local/go/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc000164998, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000164980, 0xc000193000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc000164980, 0xc000193000, 0x1000, 0x1000, 0x256758304, 0xe667c0, 0x72)
	/usr/local/go/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0000103b8, 0xc000193000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
	/usr/local/go/src/net/net.go:183 +0x91
github.com/mediocregopher/radix/v3.(*timeoutConn).Read(0xc00006a7c0, 0xc000193000, 0x1000, 0x1000, 0xa, 0x256709bad, 0xc0002f1970)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/conn.go:202 +0x5c
bufio.(*Reader).fill(0xc000076d80)
	/usr/local/go/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc000076d80, 0x1, 0xc0002e8358, 0x0, 0x0, 0x256709b00, 0xe667c0)
	/usr/local/go/src/bufio/bufio.go:139 +0x4f
github.com/mediocregopher/radix/v3/resp/resp2.Any.UnmarshalRESP(0x97b620, 0xc0002e8358, 0x0, 0xc000076d80, 0x6, 0x7)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/resp/resp2/resp.go:817 +0x8b
github.com/mediocregopher/radix/v3.(*cmdAction).UnmarshalRESP(0xc0000dbea0, 0xc000076d80, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/action.go:269 +0x4c
github.com/mediocregopher/radix/v3.(*connWrap).Decode(0xc00000f098, 0xb24280, 0xc0000dbea0, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/conn.go:93 +0x42
github.com/mediocregopher/radix/v3.(*ioErrConn).Decode(0xc00006a820, 0xb24280, 0xc0000dbea0, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/pool.go:52 +0x5c
github.com/mediocregopher/radix/v3.(*cmdAction).Run(0xc0000dbea0, 0xb2f7d8, 0xc00006a820, 0x0, 0xc000230266)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/action.go:280 +0x9b
github.com/mediocregopher/radix/v3.(*ioErrConn).Do(...)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/pool.go:62
github.com/mediocregopher/radix/v3.(*Pool).Do(0xc000352100, 0xb28ab0, 0xc0000dbea0, 0xc0000c3c40, 0xc000348120)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/pool.go:595 +0x125
...
github.com/mediocregopher/radix/v3.(*Sentinel).Do(0xc00035c000, 0xb28ab0, 0xc0000dbea0, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:205 +0xbe
github.com/mediocregopher/radix/v3.(*streamReader).backfill(0xc0002e82a0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/stream.go:362 +0x26c
github.com/mediocregopher/radix/v3.(*streamReader).Next(0xc0002e82a0, 0xb28b00, 0xc0002e82a0, 0x1, 0x1, 0x1, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/stream.go:407 +0x6d


goroutine 10 [semacquire]:
sync.runtime_SemacquireMutex(0xc00035c040, 0xb29300, 0x0)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*RWMutex).Lock(0xc00035c038)
	/usr/local/go/src/sync/rwmutex.go:116 +0x85
github.com/mediocregopher/radix/v3.(*Sentinel).ensureSentinelAddrs(0xc00035c000, 0xb2f798, 0xc00000f0c8, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:445 +0x411
github.com/mediocregopher/radix/v3.(*Sentinel).innerSpin(0xc00035c000, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:491 +0x11a
github.com/mediocregopher/radix/v3.(*Sentinel).spin(0xc00035c000)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:455 +0x85
created by github.com/mediocregopher/radix/v3.NewSentinel
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:154 +0x52b


goroutine 23 [semacquire]:
sync.runtime_SemacquireMutex(0xc00035c044, 0x0, 0x0)
	/usr/local/go/src/runtime/sema.go:71 +0x47
sync.(*RWMutex).RLock(...)
	/usr/local/go/src/sync/rwmutex.go:63
github.com/mediocregopher/radix/v3.(*Sentinel).Do(0xc00035c000, 0xb29910, 0xc000224498, 0x0, 0x0)
	/home/gabrielius/go/pkg/mod/github.com/mediocregopher/radix/v3@v3.6.0/sentinel.go:203 +0x10a
...
testing.tRunner(0xc000083080, 0xc0002e4510)
	/usr/local/go/src/testing/testing.go:1194 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1239 +0x2b3