### PR TITLE
Make EncodeDecode wait for the reader when the context is canceled.

### DIFF
--- a/action.go
+++ b/action.go
@@ -527,7 +527,7 @@ func (ec *evalAction) Perform(ctx context.Context, conn Conn) error {
 	}
 
 	err := run(false)
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT") {
+	if rErr := (resp3.SimpleError{}); errors.As(err, &rErr) && strings.HasPrefix(rErr.Error(), "NOSCRIPT") {
 		err = run(true)
 	}
 	return err

--- a/conn_test.go
+++ b/conn_test.go
@@ -8,9 +8,11 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	. "testing"
 	"time"
 
+	"github.com/mediocregopher/radix/v4/resp/resp3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +56,11 @@ func TestDialAuth(t *T) {
 				dialer.AuthPass = test.dialOptPass
 			}
 			_, err := dialer.Dial(ctx, "tcp", test.url)
+
+			// unwrap the error
+			if rErr := (resp3.SimpleError{}); errors.As(err, &rErr) {
+				err = rErr
+			}
 
 			// It's difficult to test _which_ password is being sent, but it's easy
 			// enough to tell that one was sent because redis returns an error if one
@@ -174,46 +181,106 @@ func TestConnConcurrentMarshalUnmarshal(t *T) {
 }
 
 func TestConnDeadlineExceeded(t *T) {
-	const n = 100
+	t.Run("echo", func(t *T) {
+		const p, n = 10, 100
+		conn := dial()
+		defer conn.Close()
+		ctx := testCtx(t)
 
-	subConn, pubConn := dial(), dial()
-	ctx := testCtx(t)
-	ch := randStr()
+		var wg sync.WaitGroup
+		wg.Add(p)
 
-	err := subConn.Do(ctx, Cmd(nil, "SUBSCRIBE", ch))
-	assert.NoError(t, err)
+		var numSuccesses, numTimeouts uint64
 
-	for i := 0; i < n; i++ {
-		err := pubConn.Do(ctx, FlatCmd(nil, "PUBLISH", ch, i))
+		for i := 0; i < p; i++ {
+			go func(id int) {
+				defer wg.Done()
+				for i := 0; i < n; {
+					if err := ctx.Err(); err != nil {
+						panic(err)
+					}
+
+					// the time here needs to be small enough that we get a
+					// timeout reading sometimes, but not so small that it times
+					// out everytime. By having the timeout slowly increase
+					// after every previous timeout error we can ensure we find
+					// this sweet spot in disparate test environments.
+					timeout := time.Duration(atomic.LoadUint64(&numTimeouts)) * (10 * time.Microsecond)
+					innerCtx, cancel := context.WithTimeout(ctx, timeout)
+
+					str, into := randStr(), ""
+					err := conn.Do(innerCtx, Cmd(&into, "ECHO", str))
+					cancel()
+
+					if err != nil {
+						if !assert.True(t, errors.Is(err, context.DeadlineExceeded), "err:%v", err) {
+							return
+						}
+						atomic.AddUint64(&numTimeouts, 1)
+					} else {
+						if !assert.Equal(t, str, into) {
+							return
+						}
+						atomic.AddUint64(&numSuccesses, 1)
+						i++
+					}
+				}
+			}(i)
+		}
+
+		wg.Wait()
+		t.Logf("successes:%d timeouts:%d", numSuccesses, numTimeouts)
+	})
+
+	t.Run("pubsub", func(t *T) {
+		const n = 100
+
+		subConn, pubConn := dial(), dial()
+		defer subConn.Close()
+		defer pubConn.Close()
+
+		ctx := testCtx(t)
+		ch := randStr()
+
+		err := subConn.Do(ctx, Cmd(nil, "SUBSCRIBE", ch))
 		assert.NoError(t, err)
-	}
 
-	var numTimeouts uint64
-	for i := 0; i < n; {
-		if err := ctx.Err(); err != nil {
-			panic(err)
+		for i := 0; i < n; i++ {
+			err := pubConn.Do(ctx, FlatCmd(nil, "PUBLISH", ch, i))
+			assert.NoError(t, err)
 		}
 
-		// the time here needs to be small enough that we get a timeout reading
-		// sometimes, but not so small that it times out everytime. By having
-		// the timeout slowly increase after every previous timeout error we can
-		// ensure we find this value in disparate test environments.
-		innerCtx, cancel := context.WithTimeout(ctx, time.Duration(numTimeouts)*time.Microsecond)
-
-		var msg PubSubMessage
-		err := subConn.EncodeDecode(innerCtx, nil, &msg)
-		cancel()
-
-		if err != nil {
-			assert.True(t, errors.Is(err, context.DeadlineExceeded), "err:%v", err)
-			numTimeouts++
-		} else {
-			if !assert.Equal(t, fmt.Sprint(i), string(msg.Message)) {
-				return
+		var numSuccesses, numTimeouts uint64
+		for i := 0; i < n; {
+			if err := ctx.Err(); err != nil {
+				panic(err)
 			}
-			i++
-		}
-	}
 
-	t.Logf("successes:%d timeouts:%v", n, numTimeouts)
+			// the time here needs to be small enough that we get a timeout
+			// reading sometimes, but not so small that it times out everytime.
+			// By having the timeout slowly increase after every previous
+			// timeout error we can ensure we find this sweet spot in disparate
+			// test environments.
+			innerCtx, cancel := context.WithTimeout(ctx, time.Duration(numTimeouts)*time.Microsecond)
+
+			var msg PubSubMessage
+			err := subConn.EncodeDecode(innerCtx, nil, &msg)
+			cancel()
+
+			if err != nil {
+				if !assert.True(t, errors.Is(err, context.DeadlineExceeded), "err:%v", err) {
+					return
+				}
+				numTimeouts++
+			} else {
+				if !assert.Equal(t, fmt.Sprint(i), string(msg.Message)) {
+					return
+				}
+				i++
+				numSuccesses++
+			}
+		}
+
+		t.Logf("successes:%d timeouts:%d", numSuccesses, numTimeouts)
+	})
 }

--- a/conn_writer.go
+++ b/conn_writer.go
@@ -2,9 +2,7 @@ package radix
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/mediocregopher/radix/v4/resp"
@@ -17,7 +15,6 @@ type connWriter struct {
 	doneCh <-chan struct{}
 
 	bw   resp.BufferedWriter
-	conn interface{ SetWriteDeadline(time.Time) error }
 	opts *resp.Opts
 
 	flushInterval time.Duration
@@ -41,7 +38,6 @@ func (c *conn) writer(ctx context.Context, flushInterval time.Duration) {
 		rCh:           c.rCh,
 		doneCh:        ctx.Done(),
 		bw:            c.bw,
-		conn:          c.conn,
 		opts:          c.wOpts,
 		flushInterval: flushInterval,
 	}
@@ -84,27 +80,11 @@ func (cw *connWriter) forwardToReader(mu connMarshalerUnmarshaler) bool {
 // write returns true if the write was successful
 func (cw *connWriter) write(mu connMarshalerUnmarshaler) bool {
 	if err := mu.ctx.Err(); err != nil {
-		mu.errCh <- err
+		mu.errCh <- resp.ErrConnUsable{Err: fmt.Errorf("checking context before write: %w", err)}
 		return false
-	} else if deadline, ok := mu.ctx.Deadline(); ok {
-		if err := cw.conn.SetWriteDeadline(deadline); err != nil {
-			mu.errCh <- fmt.Errorf("setting write deadline to %v: %w", deadline, err)
-			return false
-		}
-	} else if err := cw.conn.SetWriteDeadline(time.Time{}); err != nil {
-		mu.errCh <- fmt.Errorf("unsetting write deadline: %w", err)
-		return false
-	}
 
-	if err := resp3.Marshal(cw.bw, mu.marshal, cw.opts); err != nil {
-
-		// simplify things for the caller by translating network timeouts into
-		// DeadlineExceeded, since that's actually what happened.
-		if errors.Is(err, os.ErrDeadlineExceeded) {
-			err = context.DeadlineExceeded
-		}
-
-		mu.errCh <- err
+	} else if err := resp3.Marshal(cw.bw, mu.marshal, cw.opts); err != nil {
+		mu.errCh <- fmt.Errorf("marshaling message to Conn: %w", err)
 		return false
 	}
 
@@ -123,20 +103,16 @@ func (cw *connWriter) flush() bool {
 		if cw.write(mu) {
 			flushBuf = append(flushBuf, mu)
 		}
+
 	}
 	cw.flushBuf = cw.flushBuf[:0]
 
 	if err := cw.bw.Flush(); err != nil {
-
-		// simplify things for the caller by translating network timeouts into
-		// DeadlineExceeded, since that's actually what happened.
-		if errors.Is(err, os.ErrDeadlineExceeded) {
-			err = context.DeadlineExceeded
-		}
-
+		err = fmt.Errorf("flushing write buffer: %w", err)
 		for _, mu := range flushBuf {
 			mu.errCh <- err
 		}
+
 	} else {
 		for _, mu := range flushBuf {
 			// if there's no unmarshaler then don't forward to the reader

--- a/conn_writer_test.go
+++ b/conn_writer_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/mediocregopher/radix/v4/resp/resp3"
 )
 
-type nullWriteDeadliner struct{}
-
-func (nullWriteDeadliner) SetWriteDeadline(time.Time) error { return nil }
-
 type mockTicker struct {
 	paused bool
 }
@@ -287,7 +283,6 @@ func TestConnWriter(t *testing.T) {
 				wCh:         wCh,
 				rCh:         rCh,
 				bw:          bw,
-				conn:        nullWriteDeadliner{},
 				opts:        resp.NewOpts(),
 				doneCh:      doneCh,
 				eventLoopCh: make(chan struct{}),


### PR DESCRIPTION
If EncodeDecode doesn't do so then it can't be known that the response
was actually successfully read just before the context was canceled, and
so the response would just be dropped. This is especially probelematic
in the case of a pubsub reader.

Fixes #274