### PR TITLE
v4: reader can leave read buffer in an inconsistent state

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -206,7 +206,7 @@ func (c *conn) reader(ctx context.Context) {
 					mu.errCh <- fmt.Errorf("after partial read off Conn: %w", err)
 					return
 				}
-			} else if err != nil {
+			} else if err != nil && !errors.As(err, new(resp.ErrConnUsable)) {
 				go c.Close()
 				mu.errCh <- fmt.Errorf("unexpected error on Conn: %w", err)
 				return

--- a/conn.go
+++ b/conn.go
@@ -155,6 +155,7 @@ func (c *conn) reader(ctx context.Context) {
 
 			var err error
 			c.conn.resetBytesRead()
+			buffered := c.br.Buffered()
 
 			// Discard messages queued up on the wire which aren't for this
 			// EncodeDecode call. Only discard messages if the EncodeDecode
@@ -189,7 +190,7 @@ func (c *conn) reader(ctx context.Context) {
 			}
 
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				if c.conn.totalBytesRead == 0 {
+				if buffered == c.conn.Buffered() && c.conn.totalBytesRead == 0 {
 					err = resp.ErrConnUsable{Err: err}
 
 					if mu.marshal != nil {
@@ -205,6 +206,11 @@ func (c *conn) reader(ctx context.Context) {
 					mu.errCh <- fmt.Errorf("after partial read off Conn: %w", err)
 					return
 				}
+			} else if err != nil {
+				go c.Close()
+				mu.errCh <- fmt.Errorf("unexpected error on Conn: %w", err)
+				return
+
 			}
 
 			mu.errCh <- err

--- a/conn.go
+++ b/conn.go
@@ -190,7 +190,7 @@ func (c *conn) reader(ctx context.Context) {
 			}
 
 			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				if buffered == c.conn.Buffered() && c.conn.totalBytesRead == 0 {
+				if buffered == c.br.Buffered() && c.conn.totalBytesRead == 0 {
 					err = resp.ErrConnUsable{Err: err}
 
 					if mu.marshal != nil {

--- a/resp/resp.go
+++ b/resp/resp.go
@@ -84,6 +84,7 @@ type BufferedReader interface {
 	ReadSlice(delim byte) (line []byte, err error)
 	Peek(n int) ([]byte, error)
 	Discard(n int) (discarded int, err error)
+	Buffered() int
 }
 
 // BufferedWriter wraps a bufio.Writer.


### PR DESCRIPTION
Addresses inconsistent issue in #277.