### PR TITLE
Fix for #290: MaybeNil has incorrect Nil value

### DIFF
--- a/action.go
+++ b/action.go
@@ -305,6 +305,8 @@ type MaybeNil struct {
 func (mn *MaybeNil) UnmarshalRESP(br *bufio.Reader) error {
 	var rm resp2.RawMessage
 	err := rm.UnmarshalRESP(br)
+	mn.Nil = false
+	mn.EmptyArray = false
 	switch {
 	case err != nil:
 		return err


### PR DESCRIPTION
In my case, I'm re-using a `MaybeNil` object that had previously had it's `Nil` member set to true.  The solution is to always set `Nil` and `EmptyArray` when used as a receiver so that an incorrect result is never returned.