### PR TITLE
fix an endless loop when pool get in fastpath

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -533,6 +533,7 @@ func (p *Pool) getExisting() (*ioErrConn, error) {
 			return ioc, nil
 		default:
 		}
+		break // Failed to get from pool, so jump out to conduct for the next move.
 	}
 
 	if p.opts.onEmptyWait == 0 {


### PR DESCRIPTION
There is no way out when trying to get an existing connection from pool in the fast path.
This commit adds a line to break the loop when failed to obtain on the try.