### PR TITLE
Fixed CLUSTER SLOTS unmarshal for Redis 7 on radix v3 module

### DIFF
--- a/cluster_topo.go
+++ b/cluster_topo.go
@@ -198,19 +198,19 @@ func (tss *topoSlotSet) UnmarshalRESP(br *bufio.Reader) error {
 		}
 		var ip resp2.BulkString
 		if err := ip.UnmarshalRESP(br); err != nil {
-			return fmt.Errorf("Error while reading ip address. Error %v", err)
+			return fmt.Errorf("Error while reading ip address. Error %w", err)
 		}
 
 		var port resp2.Int
 		if err := port.UnmarshalRESP(br); err != nil {
-			return fmt.Errorf("Error while reading port. Error %v", err)
+			return fmt.Errorf("Error while reading port. Error %w", err)
 		}
 		nodeArrHead.N -= 2
 
 		var id resp2.BulkString
 		if nodeArrHead.N > 0 {
 			if err := id.UnmarshalRESP(br); err != nil {
-				return fmt.Errorf("Error while reading id. Error %v", err)
+				return fmt.Errorf("Error while reading id. Error %w", err)
 			}
 			nodeArrHead.N--
 		}

--- a/cluster_topo_test.go
+++ b/cluster_topo_test.go
@@ -31,7 +31,7 @@ var testTopoResp = func() resp.Marshaler {
 		),
 		respArr(5461, 8190,
 			respArr("10.128.0.36", 6379, "a3c69665bb05c8d5770407cad5b35af29e740586"),
-			respArr("10.128.0.24", 6379, "bef29809fbfe964d3b7c3ad02d3d9a40e55de317",respArr("hostname", "whatever")),
+			respArr("10.128.0.24", 6379, "bef29809fbfe964d3b7c3ad02d3d9a40e55de317", respArr("hostname", "whatever")),
 		),
 		respArr(10923, 13652,
 			respArr("10.128.0.20", 6379, "e0abc57f65496368e73a9b52b55efd00668adab7"),

--- a/cluster_topo_test.go
+++ b/cluster_topo_test.go
@@ -31,7 +31,7 @@ var testTopoResp = func() resp.Marshaler {
 		),
 		respArr(5461, 8190,
 			respArr("10.128.0.36", 6379, "a3c69665bb05c8d5770407cad5b35af29e740586"),
-			respArr("10.128.0.24", 6379, "bef29809fbfe964d3b7c3ad02d3d9a40e55de317"),
+			respArr("10.128.0.24", 6379, "bef29809fbfe964d3b7c3ad02d3d9a40e55de317",respArr("hostname", "whatever")),
 		),
 		respArr(10923, 13652,
 			respArr("10.128.0.20", 6379, "e0abc57f65496368e73a9b52b55efd00668adab7"),
@@ -150,15 +150,15 @@ func TestClusterTopo(t *T) {
 func TestClusterTopoSplitSlots(t *T) {
 	clusterSlotsResp := respArr(
 		respArr(0, 0,
-			respArr("127.0.0.1", "7001", "90900dd4ef2182825bc853c448737b2ba9975a50"),
-			respArr("127.0.0.1", "7011", "073a013f8886b6cf4c1b018612102601534912e9"),
+			respArr("127.0.0.1", 7001, "90900dd4ef2182825bc853c448737b2ba9975a50"),
+			respArr("127.0.0.1", 7011, "073a013f8886b6cf4c1b018612102601534912e9"),
 		),
 		respArr(1, 8191,
-			respArr("127.0.0.1", "7000", "3ff1ddc420cfceeb4c42dc4b1f8f85c3acf984fe"),
+			respArr("127.0.0.1", 7000, "3ff1ddc420cfceeb4c42dc4b1f8f85c3acf984fe"),
 		),
 		respArr(8192, 16383,
-			respArr("127.0.0.1", "7001", "90900dd4ef2182825bc853c448737b2ba9975a50"),
-			respArr("127.0.0.1", "7011", "073a013f8886b6cf4c1b018612102601534912e9"),
+			respArr("127.0.0.1", 7001, "90900dd4ef2182825bc853c448737b2ba9975a50"),
+			respArr("127.0.0.1", 7011, "073a013f8886b6cf4c1b018612102601534912e9"),
 		),
 	)
 	expTopo := ClusterTopo{
@@ -201,7 +201,7 @@ func TestClusterTopoSplitSlots(t *T) {
 func TestIPV6ClusterTopo(t *T) {
 	clusterSlotsResp := respArr(
 		respArr(0, 0,
-			respArr("8ffd:50::d4eb", "7001", "90900dd4ef2182825bc853c448737b2ba9975a50"),
+			respArr("8ffd:50::d4eb", 7001, "90900dd4ef2182825bc853c448737b2ba9975a50"),
 		),
 	)
 	expTopo := ClusterTopo{


### PR DESCRIPTION
As described in https://github.com/mediocregopher/radix/issues/316, redis 7 now includes a map of additional networking metadata on the CLUSTER SLOTS inner array replies. 
from:
```
127.0.0.1:7000> cluster slots
1) 1) (integer) 0
   2) (integer) 5460
   3) 1) "127.0.0.1"
      2) (integer) 7000
      3) "0d9f891506bd8762cbf10285239c75bacef86b0b"
(...)
```
to:

```
127.0.0.1:7000> cluster slots
1) 1) (integer) 0
   2) (integer) 5460
   3) 1) "127.0.0.1"
      2) (integer) 7000
      3) "2059dbe24a3ecce58d920cba4e2193ad0a7c0891"
      4) (empty array)
(...)
```

I noticed https://github.com/mediocregopher/radix/pull/320 addresses it for v4 radix but as many of us still use the non compatible v3 I believe the fix should address v3 as well. 

Confirmation it's working as expected:
```
$ go test . -v -test.run TestClusterTopo
=== RUN   TestClusterTopo
--- PASS: TestClusterTopo (0.00s)
=== RUN   TestClusterTopoSplitSlots
--- PASS: TestClusterTopoSplitSlots (0.00s)
PASS
ok      github.com/mediocregopher/radix/v3      0.033s
```