### PR TITLE
Fix discarding of error values

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -174,7 +174,12 @@ func (c *conn) reader(ctx context.Context) {
 					discardMU := el.Value.(connMarshalerUnmarshaler)
 
 					if err = resp3.Unmarshal(c.br, discardMU.unmarshalInto, c.rOpts); err != nil {
-						break
+						// Ignore RESP errors.
+						if !errors.As(err, &resp3.SimpleError{}) && !errors.As(err, &resp3.BlobError{}) {
+							break
+						}
+
+						err = nil
 					}
 
 					discardList.Remove(el)


### PR DESCRIPTION
Fixes #313 

When discarding the responses from previous commands that weren't
successfully read (e.g. if their context had a deadline that was
exceeded), RESP error values get treated the same as connection errors
and cause any reading from the connection to stop. This can cause a
response to not be read off of the connection or marked for discarding,
and therefore leave the connection out of sync.

This fix disables error bubbling during the discarding process to
prevent these error values from interfering.