### PR TITLE
Add special key handling for MEMORY USAGE

### DIFF
--- a/action.go
+++ b/action.go
@@ -233,6 +233,8 @@ func DefaultActionProperties(cmd string, args ...string) ActionProperties {
 	case noKeyCmds[cmd] || len(args) == 0:
 	case cmd == "BITOP" && len(args) > 1:
 		properties.Keys = args[1:]
+	case cmd == "MEMORY" && len(args) > 1 && strings.ToUpper(args[0]) == "USAGE":
+		properties.Keys = args[1:2]
 	case cmd == "MSET":
 		properties.Keys = keysFromKeyValuePairs(args)
 	case cmd == "XINFO":

--- a/action_test.go
+++ b/action_test.go
@@ -44,6 +44,11 @@ func TestCmdAction(t *T) {
 	var dstval string
 	require.Nil(t, c.Do(ctx, Cmd(&dstval, "GET", key+key)))
 	assert.Equal(t, val, dstval)
+
+	// MEMORY USAGE needs special handling
+	memoryUsageCmd := Cmd(nil, "MEMORY", "USAGE", key)
+	assert.Equal(t, []string{key}, memoryUsageCmd.Properties().Keys)
+	require.Nil(t, c.Do(ctx, memoryUsageCmd))
 }
 
 func TestCmdActionMSet(t *T) {


### PR DESCRIPTION
Add special handling for the MEMORY USAGE command to extract the key
from the second argument.

Fixes #324.