### PR TITLE
Consistent flattening behaviour for empty slices in structs

### DIFF
--- a/resp/resp3/flatten_test.go
+++ b/resp/resp3/flatten_test.go
@@ -1,0 +1,33 @@
+package resp3
+
+import (
+	"testing"
+
+	"github.com/mediocregopher/radix/v4/resp"
+	"github.com/stretchr/testify/suite"
+)
+
+type FlattenTestSuite struct {
+	suite.Suite
+}
+
+type NestedStruct struct{}
+
+type sliceTestStruct struct {
+	Other  string
+	Nested []NestedStruct
+}
+
+func (s *FlattenTestSuite) TestEmptyNestedSlice() {
+	testInst := sliceTestStruct{
+		Other: "hello",
+	}
+
+	flat, err := Flatten(testInst, resp.NewOpts())
+	s.NoError(err)
+	s.Equal([]string{"Other", "hello"}, flat)
+}
+
+func TestFlattenTestSuite(t *testing.T) {
+	suite.Run(t, new(FlattenTestSuite))
+}

--- a/resp/resp3/flatten_test.go
+++ b/resp/resp3/flatten_test.go
@@ -13,18 +13,33 @@ type FlattenTestSuite struct {
 
 type NestedStruct struct{}
 
-type sliceTestStruct struct {
-	Other  string
-	Nested []NestedStruct
-}
-
+// Test whether by default, an empty slice in a hashmap should be flattened to an empty value.
 func (s *FlattenTestSuite) TestEmptyNestedSlice() {
-	testInst := sliceTestStruct{
+	testInst := struct {
+		Other  string
+		Nested []NestedStruct
+	}{
 		Other: "hello",
 	}
 
 	flat, err := Flatten(testInst, resp.NewOpts())
 	s.NoError(err)
+
+	s.Equal([]string{"Other", "hello", "Nested", ""}, flat)
+}
+
+// Test with omitempty; empty slices should be left off altogether.
+func (s *FlattenTestSuite) TestOmitEmptyNestedSlice() {
+	testInst := struct {
+		Other           string
+		NestedOmitEmpty []NestedStruct `redis:",omitempty"`
+	}{
+		Other: "hello",
+	}
+
+	flat, err := Flatten(testInst, resp.NewOpts())
+	s.NoError(err)
+
 	s.Equal([]string{"Other", "hello"}, flat)
 }
 

--- a/resp/resp3/flatten_test.go
+++ b/resp/resp3/flatten_test.go
@@ -14,31 +14,26 @@ type FlattenTestSuite struct {
 // Test whether by default, an empty slice in a hashmap should be flattened to an empty value.
 func (s *FlattenTestSuite) TestEmptyNestedSlice() {
 	testInst := struct {
-		Other  string
 		Nested []string
-	}{
-		Other: "hello",
-	}
+	}{}
 
 	flat, err := Flatten(testInst, resp.NewOpts())
 	s.NoError(err)
 
-	s.Equal([]string{"Other", "hello", "Nested", ""}, flat)
+	s.Equal([]string{"Nested", ""}, flat)
 }
 
 // Test with omitempty; empty slices should be left off altogether.
 func (s *FlattenTestSuite) TestOmitEmptyNestedSlice() {
 	testInst := struct {
-		Other           string
+		Other           string   // We need at least one non-empty value for commands like HMSET.
 		NestedOmitEmpty []string `redis:",omitempty"`
-	}{
-		Other: "hello",
-	}
+	}{}
 
 	flat, err := Flatten(testInst, resp.NewOpts())
 	s.NoError(err)
 
-	s.Equal([]string{"Other", "hello"}, flat)
+	s.Equal([]string{"Other", ""}, flat)
 }
 
 func TestFlattenTestSuite(t *testing.T) {

--- a/resp/resp3/flatten_test.go
+++ b/resp/resp3/flatten_test.go
@@ -11,13 +11,11 @@ type FlattenTestSuite struct {
 	suite.Suite
 }
 
-type NestedStruct struct{}
-
 // Test whether by default, an empty slice in a hashmap should be flattened to an empty value.
 func (s *FlattenTestSuite) TestEmptyNestedSlice() {
 	testInst := struct {
 		Other  string
-		Nested []NestedStruct
+		Nested []string
 	}{
 		Other: "hello",
 	}
@@ -32,7 +30,7 @@ func (s *FlattenTestSuite) TestEmptyNestedSlice() {
 func (s *FlattenTestSuite) TestOmitEmptyNestedSlice() {
 	testInst := struct {
 		Other           string
-		NestedOmitEmpty []NestedStruct `redis:",omitempty"`
+		NestedOmitEmpty []string `redis:",omitempty"`
 	}{
 		Other: "hello",
 	}

--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -2255,7 +2255,7 @@ func getStructFields(t reflect.Type) map[string]structField {
 			}
 
 			key, fromTag := ft.Name, false
-			if tag := ft.Tag.Get("redis"); tag != "" && tag != "-" {
+			if tag, _ := parseTag(ft.Tag.Get("redis")); tag != "" && tag != "-" {
 				key, fromTag = tag, true
 			}
 			if m[key].fromTag {

--- a/resp/resp3/tags.go
+++ b/resp/resp3/tags.go
@@ -1,0 +1,38 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package resp3
+
+import (
+	"strings"
+)
+
+// tagOptions is the string following a comma in a struct field's "json"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	tag, opt, _ := strings.Cut(tag, ",")
+	return tag, tagOptions(opt)
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var name string
+		name, s, _ = strings.Cut(s, ",")
+		if name == optionName {
+			return true
+		}
+	}
+	return false
+}

--- a/resp/resp3/tags_test.go
+++ b/resp/resp3/tags_test.go
@@ -1,0 +1,28 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package resp3
+
+import (
+	"testing"
+)
+
+func TestTagParsing(t *testing.T) {
+	name, opts := parseTag("field,foobar,foo")
+	if name != "field" {
+		t.Fatalf("name = %q, want field", name)
+	}
+	for _, tt := range []struct {
+		opt  string
+		want bool
+	}{
+		{"foobar", true},
+		{"foo", true},
+		{"bar", false},
+	} {
+		if opts.Contains(tt.opt) != tt.want {
+			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Test demonstrating #330 and a proposed solution to it consistent with (and copied/borrowed from) Go's own `encoding/json` package:

1. By default, an empty slice in a struct will flatten to `""`.
2. When the tag option `omitempty` is used, the field will be not be present at all.

Regrettably, I found the code in `marshal_unmarshal_test.go` inaccessible. To respect my time and sanity and as a suggestion to the maintainer of `radix`, not withstanding my gratitude to them for a great library, I have created a separate testify test suite for the `Flatten()` function.