### PR TITLE
exclude redis slaves what are subjectively down

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -295,6 +295,10 @@ func (sc *Sentinel) ensureClients(ctx context.Context, conn Conn) error {
 
 	newClients := map[string]Client{newPrimAddr: nil}
 	for _, secM := range secMM {
+		// means it's down with flag "s_down,slave"
+		if secM["flags"] != "slave" {
+			continue
+		}
 		newSecAddr, err := sentinelMtoAddr(secM, "SENTINEL SLAVES")
 		if err != nil {
 			return err


### PR DESCRIPTION
## Problem
There can be cases when `redis` slaves will be in subjectively down state. Currently it breaks connection to `redis` totally when it happened to be `master` before.
Proposed fix is to check `flags` and exclude such `slave` instances.

Related issue:
https://github.com/mediocregopher/radix/issues/342
