### PR TITLE
Fix blocking when unmarshaling the slice of stream entries

### DIFF
--- a/resp/resp3/resp.go
+++ b/resp/resp3/resp.go
@@ -2005,10 +2005,6 @@ func keyableReceiver(prefix Prefix, kv reflect.Value) (reflect.Value, error) {
 }
 
 func unmarshalAgg(prefix Prefix, br resp.BufferedReader, l int64, rcv interface{}, o *resp.Opts) error {
-	if prefix == MapHeaderPrefix {
-		l *= 2
-	}
-
 	if !o.DisableErrorBubbling {
 		if o == nil {
 			o = resp.NewOpts()
@@ -2021,6 +2017,9 @@ func unmarshalAgg(prefix Prefix, br resp.BufferedReader, l int64, rcv interface{
 	}
 
 	size := int(l)
+	if prefix == MapHeaderPrefix {
+		size *= 2
+	}
 	stream := size < 0
 	if rcv == nil {
 		return discardMulti(br, size, o)
@@ -2041,6 +2040,9 @@ func unmarshalAgg(prefix Prefix, br resp.BufferedReader, l int64, rcv interface{
 	switch v.Kind() {
 	case reflect.Slice:
 		slice := v
+		if slice.Type().Elem().Kind() == reflect.Struct {
+			size = int(l)
+		}
 		if size > slice.Cap() || slice.IsNil() {
 			sliceSize := size
 			if stream {


### PR DESCRIPTION
Hello! There is a problem with unmarshaling the slice of StreamEntries when using the RESP3 protocol. In RESP3, the reply for XREADGROUP is a map. When Radix unmarshals this map, it doubles the expected size:
```
func unmarshalAgg(prefix Prefix, br resp.BufferedReader, l int64, rcv interface{}, o *resp.Opts) error {
	if prefix == MapHeaderPrefix {
		l *= 2
	}
        .....
        size := int(l)
```
This causes a block when attempting to use a slice of structs ([]StreamEntries) because the code below tries to fetch a doubled amount of elements:
```
		for i := 0; i < size || stream; i++ {
			into.Elem().Set(reflect.Zero(into.Type().Elem()))
			if more, err := maybeUnmarshalRESP(br, stream, into.Interface(), o); err != nil {
				return discardMultiAfterErr(br, size-i-1, err, o)
			} else if !more {
				break
			}
			slice = reflect.Append(slice, into.Elem())
		}
``` 
